### PR TITLE
fix: workingDir, WORKFLOW_DIR and SUBAGENT placeholders

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -45,7 +45,7 @@ Task(
 
 The sub-agent's prompt instructs IT to call `Skill("sdd-{phase}")` — the orchestrator never calls Skill itself.
 
-Full launch templates (copy-paste ready) are in `{SKILLS_PATH}/_shared/launch-templates.md` — read them before your first launch.
+Full launch templates (copy-paste ready) are in `{WORKFLOW_DIR}/_shared/launch-templates.md` — read them before your first launch.
 
 Model assignment: use the Phase-to-Model Table above when passing `model:` to the Task call.
 
@@ -55,13 +55,13 @@ Before the first launch, save the active-workflow marker to engram (if available
 ```
 mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {SKILLS_PATH}/ORCHESTRATOR.md. Phase: starting explore.")
+  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. Phase: starting explore.")
 ```
 
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 
-1. **Parse** the SDD Envelope from sub-agent output (format: `{SKILLS_PATH}/_shared/envelope-contract.md`)
-2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{SKILLS_PATH}/_shared/persistence-contract.md`
+1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`)
+2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`
 3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
 4. **Show** executive summary to user (verbatim from envelope)
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
@@ -83,7 +83,7 @@ Triggered automatically by Post-Phase Protocol step 5 when `which crit` succeeds
 3. **Read feedback**: Read `~/.crit/plans/{change}/.crit.json` using the Read tool. Note: plan mode stores `.crit.json` in `~/.crit/plans/{change}/`, NOT in the project root.
 4. **Parse**: Extract all comments where `resolved` is `false` or missing.
 5. **Branch**:
-   - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{SKILLS_PATH}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
+   - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
    - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 6 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
@@ -109,7 +109,7 @@ A large plan exhausts a single sub-agent's context. The orchestrator drives wave
 
 1. Read the Batch Assignment Table from `.sdd/{change}/plan.md` (metadata only, not source code)
 2. Group batches into waves by dependency satisfaction; `Parallel=Yes` batches run simultaneously
-3. Launch one sub-agent per wave (see `{SKILLS_PATH}/_shared/launch-templates.md` for template)
+3. Launch one sub-agent per wave (see `{WORKFLOW_DIR}/_shared/launch-templates.md` for template)
 4. After each wave:
    - `status: ok` -> verify `[X]` markers in plan.md, show progress via `AskUserQuestion`, launch next wave
    - `status: failed` -> STOP, show failure: **Retry wave** / **Abort** / **Skip to next wave**
@@ -138,11 +138,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", ..., content: "COMPLETED|ABO
 
 ## Edge Cases and Recovery
 
-Compaction recovery, fail-fast error handling, abort/complete cleanup, and non-SDD context injection are in `{SKILLS_PATH}/_shared/recovery.md`.
+Compaction recovery, fail-fast error handling, abort/complete cleanup, and non-SDD context injection are in `{WORKFLOW_DIR}/_shared/recovery.md`.
 
 ## References
 
-- Envelope format: `{SKILLS_PATH}/_shared/envelope-contract.md`
-- Persistence rules: `{SKILLS_PATH}/_shared/persistence-contract.md`
-- Launch templates: `{SKILLS_PATH}/_shared/launch-templates.md`
-- Recovery flows: `{SKILLS_PATH}/_shared/recovery.md`
+- Envelope format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`
+- Persistence rules: `{WORKFLOW_DIR}/_shared/persistence-contract.md`
+- Launch templates: `{WORKFLOW_DIR}/_shared/launch-templates.md`
+- Recovery flows: `{WORKFLOW_DIR}/_shared/recovery.md`

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -1,3 +1,5 @@
+Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
+
 ## SDD — Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**
@@ -23,8 +25,8 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 ## SDD — How to Start (MANDATORY)
 
 When SDD is triggered:
-1. Read `{SKILLS_PATH}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your playbook
-2. Read `{SKILLS_PATH}/_shared/launch-templates.md` — these are your copy-paste templates for Task() calls
+1. Read `{WORKFLOW_DIR}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your playbook
+2. Read `{WORKFLOW_DIR}/_shared/launch-templates.md` — these are your copy-paste templates for Task() calls
 3. Create artifact directory: `mkdir -p .sdd/{change-name}` (use RELATIVE path, not absolute)
 4. Follow the Orchestrator instructions to launch sub-agents via `Task()` tool
 
@@ -34,17 +36,17 @@ When SDD is triggered:
 ## SDD — Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Task()`.
-2. To launch a phase: use `Task()` with prompt that tells the sub-agent to call `Skill("sdd-{phase}")`. See `{SKILLS_PATH}/_shared/launch-templates.md` for exact templates.
+2. To launch a phase: use `Task()` with prompt that tells the sub-agent to call `Skill("sdd-{phase}")`. See `{WORKFLOW_DIR}/_shared/launch-templates.md` for exact templates.
 3. After EVERY sub-agent, execute the Post-Phase Protocol from ORCHESTRATOR.md — NEVER skip it.
 4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
-Full orchestrator instructions: {SKILLS_PATH}/ORCHESTRATOR.md
+Full orchestrator instructions: {WORKFLOW_DIR}/ORCHESTRATOR.md
 
 ### SDD -- Compaction Recovery (MANDATORY)
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
-1. Re-read `{SKILLS_PATH}/ORCHESTRATOR.md` and its recovery reference `{SKILLS_PATH}/_shared/recovery.md`.
+1. Re-read `{WORKFLOW_DIR}/ORCHESTRATOR.md` and its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
 3. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
 

--- a/workflows/sdd/_shared/launch-templates.md
+++ b/workflows/sdd/_shared/launch-templates.md
@@ -4,10 +4,18 @@
 
 All SDD phases use this template. Replace `{phase}` with explore/plan/implement/review.
 
+Subagent type mapping per phase:
+| Phase | Subagent Type |
+|-------|---------------|
+| explore | `{WORKFLOW_SUBAGENT_EXPLORER}` |
+| plan | `{WORKFLOW_SUBAGENT_PLANNER}` |
+| implement | `{WORKFLOW_SUBAGENT_IMPLEMENTER}` |
+| review | `{WORKFLOW_SUBAGENT_REVIEWER}` |
+
 ```
 Task(
   description: '{phase} for {change-name}',
-  subagent_type: 'general',
+  subagent_type: '{subagent type from table above}',
   model: '{model from Phase-to-Model Table}',
   prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading your phase instructions via the Skill tool:
 
@@ -25,7 +33,7 @@ Task(
   TASK:
   {specific task description}
 
-  PERSISTENCE: See {project path}/{SKILLS_PATH}/_shared/persistence-contract.md
+  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
   - Primary: always write to .sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
@@ -41,7 +49,7 @@ The implement phase is special: the orchestrator reads plan.md and launches one 
 ```
 Task(
   description: 'implement wave {N} for {change-name}',
-  subagent_type: 'general',
+  subagent_type: '{WORKFLOW_SUBAGENT_IMPLEMENTER}',
   model: '{WORKFLOW_MODEL_IMPLEMENTER}',
   prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading:
 
@@ -68,7 +76,7 @@ Task(
 
   Do NOT implement batches beyond this wave. The orchestrator manages wave progression.
 
-  PERSISTENCE: See {project path}/{SKILLS_PATH}/_shared/persistence-contract.md'
+  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md'
 )
 ```
 
@@ -79,7 +87,7 @@ When the orchestrator re-enters `sdd-plan` after a Crit review round:
 ```
 Task(
   description: 'plan re-entry (crit round {N}) for {change-name}',
-  subagent_type: 'general',
+  subagent_type: '{WORKFLOW_SUBAGENT_PLANNER}',
   model: 'opus',
   prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading your phase instructions via the Skill tool:
 
@@ -104,7 +112,7 @@ Task(
   Re-run the Detail Quality Gate.
   Return the SDD Envelope.
 
-  PERSISTENCE: See {project path}/{SKILLS_PATH}/_shared/persistence-contract.md
+  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
   - Primary: always write to .sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
@@ -124,7 +132,7 @@ mem_save(
   topic_key: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
   title: "sdd/{change}/active-workflow",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {SKILLS_PATH}/ORCHESTRATOR.md. Phase: starting explore."
+  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. Phase: starting explore."
 )
 ```
 

--- a/workflows/sdd/_shared/recovery.md
+++ b/workflows/sdd/_shared/recovery.md
@@ -8,7 +8,7 @@ You arrived here because the catalog's Compaction Recovery directive detected an
 
 1. **Primary -- Read `.sdd/{change}/state.yaml`** (always works, file-based):
    - Parse YAML to get `current_phase`, `phases` map, and `artifacts` list
-   - Schema defined in `{SKILLS_PATH}/_shared/persistence-contract.md`
+   - Schema defined in `{WORKFLOW_DIR}/_shared/persistence-contract.md`
 
 2. **Fallback -- Engram** (only if state.yaml is missing AND engram is available):
    ```
@@ -17,7 +17,7 @@ You arrived here because the catalog's Compaction Recovery directive detected an
    ```
    NEVER use `mem_search` previews directly -- they are truncated.
 
-3. **Resume**: Continue from the next pending phase. Delegate via sub-agents using launch templates in `{SKILLS_PATH}/_shared/launch-templates.md`. If no state is recoverable, inform the user: **Restart** / **Abort**.
+3. **Resume**: Continue from the next pending phase. Delegate via sub-agents using launch templates in `{WORKFLOW_DIR}/_shared/launch-templates.md`. If no state is recoverable, inform the user: **Restart** / **Abort**.
 
 ## Fail-Fast Error Handling
 

--- a/workflows/sdd/workflow.yaml
+++ b/workflows/sdd/workflow.yaml
@@ -1,8 +1,9 @@
 apiVersion: devrune/workflow/v1
 metadata:
-  name: "SDD (Spec-Driven Development)"
-  description: "Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding."
+  name: sdd
+  displayName: "SDD (Spec-Driven Development)"
   version: "1.0.0"
+  workingDir: sdd-orchestrator
 components:
   skills:
     - sdd-explore


### PR DESCRIPTION
## Summary
- `workflow.yaml`: `name` → slug (`sdd`), add `displayName` and `workingDir: sdd-orchestrator`
- Replace `{SKILLS_PATH}` with `{WORKFLOW_DIR}` for workflow file references (orchestrator, `_shared/`)
- Keep `{SKILLS_PATH}` for skill fallback paths (correctly points to base skills dir)
- Replace hardcoded `subagent_type: 'general'` with `{WORKFLOW_SUBAGENT_*}` placeholders
- Add subagent type mapping table to generic launch template

## Test plan
- [x] Verified placeholder resolution for all agents after `devrune sync`
- [x] Claude → `general`, OpenCode/Copilot → role names, Factory/Codex → `general`

> Companion to DevRune PR: davidarce/DevRune#new

🤖 Generated with [Claude Code](https://claude.com/claude-code)