### PR TITLE
feat: add compaction recovery hooks and plugins for SDD

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -54,7 +54,26 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
-3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
+3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
+
+   **NEXT Step Resolution** — set the NEXT directive based on what just completed:
+   - After explore `ok`: `NEXT: plan phase -> deep interview then crit detection`
+   - After plan `ok` (pre-crit): `NEXT: plan phase -> crit detection then ask user`
+   - After plan `ok` (post-crit, approved): `NEXT: implement phase -> wave 1 batch A`
+   - After implement `ok` (more waves remaining): `NEXT: implement phase -> wave {N} batch {ID}`
+   - After implement `ok` (all waves done): `NEXT: review phase -> auto-launch review`
+   - After review: `NEXT: review phase -> post-review fix cycle`
+
+   Update `active-workflow` marker:
+   ```
+   mcp__engram__mem_save(
+     topic_key: "sdd/{change}/active-workflow",
+     type: "architecture", project: "{project}",
+     title: "sdd/{change}/active-workflow",
+     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.copilot.md. NEXT: {phase} phase -> {next step}."
+   )
+   ```
+
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
@@ -65,6 +84,11 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → Ask the user: **Continue to {next}** / **Review artifacts** / **Abort**
+
+   **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
+   - Check `crit_completed` in `.sdd/{change}/state.yaml`.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the ask above.
 
 ## Crit Plan Review Protocol
 

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -51,7 +51,26 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
-3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
+3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
+
+   **NEXT Step Resolution** — set the NEXT directive based on what just completed:
+   - After explore `ok`: `NEXT: plan phase -> deep interview then crit detection`
+   - After plan `ok` (pre-crit): `NEXT: plan phase -> crit detection then ask user`
+   - After plan `ok` (post-crit, approved): `NEXT: implement phase -> wave 1 batch A`
+   - After implement `ok` (more waves remaining): `NEXT: implement phase -> wave {N} batch {ID}`
+   - After implement `ok` (all waves done): `NEXT: review phase -> auto-launch review`
+   - After review: `NEXT: review phase -> post-review fix cycle`
+
+   Update `active-workflow` marker:
+   ```
+   mem_save(
+     topic_key: "sdd/{change}/active-workflow",
+     type: "architecture", project: "{project}",
+     title: "sdd/{change}/active-workflow",
+     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. NEXT: {phase} phase -> {next step}."
+   )
+   ```
+
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
@@ -62,6 +81,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
+
+   **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
+   - Check `crit_completed` in `.sdd/{change}/state.yaml`.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` above.
 
 ## Crit Plan Review Protocol
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -50,7 +50,26 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
-3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
+3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
+
+   **NEXT Step Resolution** — set the NEXT directive based on what just completed:
+   - After explore `ok`: `NEXT: plan phase -> deep interview then crit detection`
+   - After plan `ok` (pre-crit): `NEXT: plan phase -> crit detection then ask user`
+   - After plan `ok` (post-crit, approved): `NEXT: implement phase -> wave 1 batch A`
+   - After implement `ok` (more waves remaining): `NEXT: implement phase -> wave {N} batch {ID}`
+   - After implement `ok` (all waves done): `NEXT: review phase -> auto-launch review`
+   - After review: `NEXT: review phase -> post-review fix cycle`
+
+   Update `active-workflow` marker:
+   ```
+   mem_save(
+     topic_key: "sdd/{change}/active-workflow",
+     type: "architecture", project: "{project}",
+     title: "sdd/{change}/active-workflow",
+     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. NEXT: {phase} phase -> {next step}."
+   )
+   ```
+
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
@@ -61,6 +80,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
+
+   **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
+   - Check `crit_completed` in `.sdd/{change}/state.yaml`.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` above.
 
 ## Crit Plan Review Protocol
 

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -53,6 +53,8 @@ After compaction, if memory has `sdd/*/active-workflow` observations starting wi
 
 1. Re-read `{WORKFLOW_DIR}/ORCHESTRATOR.md` and its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
-3. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
+3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
+4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.
+5. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
 
 If no `active-workflow` marker is found, do nothing.

--- a/workflows/sdd/hooks/sdd-hooks-claude.json
+++ b/workflows/sdd/hooks/sdd-hooks-claude.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sdd-pre-compact.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sdd-session-compact.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/workflows/sdd/hooks/sdd-hooks-factory.json
+++ b/workflows/sdd/hooks/sdd-hooks-factory.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "PreCompact": [{
+      "type": "command",
+      "command": "\"$FACTORY_PROJECT_DIR\"/.factory/hooks/sdd-pre-compact.sh"
+    }]
+  }
+}

--- a/workflows/sdd/hooks/sdd-pre-compact.sh
+++ b/workflows/sdd/hooks/sdd-pre-compact.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SDD Pre-Compaction Hook
+# Ensures .sdd/ state is persisted before context compaction.
+for state_file in .sdd/*/state.yaml; do
+  [ -f "$state_file" ] || continue
+  change_name="$(basename "$(dirname "$state_file")")"
+  touch "$state_file"
+  echo "[sdd-hook] Pre-compaction: verified state for $change_name"
+done

--- a/workflows/sdd/hooks/sdd-session-compact.sh
+++ b/workflows/sdd/hooks/sdd-session-compact.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# SDD SessionStart(compact) Hook (Tier 1a — Claude only)
+# Fires when Claude resumes after compaction. Stdout becomes visible context.
+for state_file in .sdd/*/state.yaml; do
+  [ -f "$state_file" ] || continue
+  change_name="$(basename "$(dirname "$state_file")")"
+  current_phase="$(grep '^current_phase:' "$state_file" | sed 's/current_phase: *//')"
+  next_step="$(grep '^next_step:' "$state_file" | sed 's/next_step: *//')"
+  [ -z "$current_phase" ] && current_phase="unknown"
+  [ -z "$next_step" ] && next_step="check state.yaml for details"
+  echo "CRITICAL: SDD workflow was active during compaction. You MUST run compaction recovery NOW."
+  echo "Read .sdd/${change_name}/state.yaml and check engram for active-workflow marker."
+  echo "Load Skill(sdd-orchestrator) and resume from the NEXT directive in the marker."
+  echo "Current phase: ${current_phase}. NEXT: ${next_step}."
+done

--- a/workflows/sdd/plugins/sdd-compaction.ts
+++ b/workflows/sdd/plugins/sdd-compaction.ts
@@ -1,0 +1,42 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import type { Plugin } from "@opencode-ai/plugin";
+
+export const SddCompaction: Plugin = async (_ctx) => {
+  return {
+    "experimental.session.compacting": async (
+      _input: unknown,
+      output: { context: { push: (s: string) => void } }
+    ) => {
+      const sddDir = ".sdd";
+      if (!existsSync(sddDir)) return;
+      const changes = readdirSync(sddDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .filter((d) => existsSync(join(sddDir, d.name, "state.yaml")));
+      if (changes.length === 0) return;
+      for (const c of changes) {
+        const stateFile = join(sddDir, c.name, "state.yaml");
+        const stateContent = readFileSync(stateFile, "utf-8");
+        const phaseMatch = stateContent.match(/^current_phase:\s*(.+)$/m);
+        const nextMatch = stateContent.match(/^next_step:\s*(.+)$/m);
+        const currentPhase = phaseMatch?.[1] ?? "unknown";
+        const nextStep = nextMatch?.[1] ?? "check state.yaml";
+        output.context.push(`## SDD Workflow Recovery (CRITICAL)
+ACTIVE SDD workflow: ${c.name}
+Current phase: ${currentPhase}
+NEXT: ${nextStep}
+
+You MUST run compaction recovery NOW:
+1. Read .sdd/${c.name}/state.yaml for full state
+2. Check engram for active-workflow marker (mem_context)
+3. Load Skill(sdd-orchestrator) and resume from NEXT directive
+
+Full state.yaml content:
+\`\`\`yaml
+${stateContent}
+\`\`\`
+`);
+      }
+    },
+  };
+};

--- a/workflows/sdd/workflow.yaml
+++ b/workflows/sdd/workflow.yaml
@@ -77,5 +77,13 @@ components:
     - "Bash(git status:*)"
     - "Skill(git-commit)"
     - "Skill(git-pull-request)"
+  hooks:
+    agents:
+      claude:
+        - definition: hooks/sdd-hooks-claude.json
+      factory:
+        - definition: hooks/sdd-hooks-factory.json
+      opencode:
+        - definition: plugins/sdd-compaction.ts
   gitignore:
     - ".sdd/"


### PR DESCRIPTION
## Summary

- Add hook definitions, shell scripts, and TypeScript plugin for SDD compaction recovery
- Sync ORCHESTRATOR variants with NEXT Step Resolution and crit_completed guard
- Update REGISTRY.md recovery steps with NEXT directive parsing

## New files

- `workflows/sdd/hooks/sdd-hooks-claude.json` — Claude PreCompact + SessionStart hooks
- `workflows/sdd/hooks/sdd-hooks-factory.json` — Factory PreCompact hook
- `workflows/sdd/hooks/sdd-pre-compact.sh` — touches state.yaml before compaction
- `workflows/sdd/hooks/sdd-session-compact.sh` — injects recovery context after compaction
- `workflows/sdd/plugins/sdd-compaction.ts` — OpenCode plugin (named export, dot-notation hooks)

## Test plan

- [x] Claude compaction recovery tested (PreCompact + SessionStart)
- [x] OpenCode compaction recovery tested (plugin auto-load)
- [x] Copilot/Codex: no hooks directory copied (verified)
- [x] `devrune install` installs assets only to declared agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)