### PR TITLE
feat: advisor strategy — guidance loop, model placeholder, adviser mode

### DIFF
--- a/skills/api-first-adviser/SKILL.md
+++ b/skills/api-first-adviser/SKILL.md
@@ -80,3 +80,60 @@ Before finalizing your review, check `gotchas.md` for common Claude mistakes in 
 - [ ] Dates in ISO 8601 UTC format
 - [ ] `Location` header returned on 201 Created responses
 - [ ] Deprecation communicated via `Sunset` and `Deprecation` headers
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In adviser mode, focus on contract specs and API shape from the plan (not codebase files).
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: REST conventions, OpenAPI spec quality, error models, versioning.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/api-first-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/skills/architect-adviser/SKILL.md
+++ b/skills/architect-adviser/SKILL.md
@@ -70,7 +70,7 @@ Apply Beck's 4 Rules of Simple Design in order:
 | Speculative generality | Interface with one implementation and no planned extension |
 | Generic naming | Classes named `Manager`, `Helper`, `Utils`, `Processor` |
 
-## Output Format
+## Output Format (Standard Review Mode)
 
 Structure findings as:
 
@@ -94,3 +94,60 @@ Structure findings as:
 ```
 
 Before finalizing your review, check `gotchas.md` for common Claude mistakes in this domain.
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: Architecture patterns, layer separation, dependency flow, DDD tactical patterns.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/architect-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/skills/component-adviser/SKILL.md
+++ b/skills/component-adviser/SKILL.md
@@ -80,3 +80,60 @@ When reviewing React components:
 - [ ] Context values are memoized to prevent unnecessary re-renders
 - [ ] Components are composable — children/render props used for extensibility
 - [ ] No business logic in components (use hooks or services)
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: React component patterns, hooks, props design, state management.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/component-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/skills/frontend-test-adviser/SKILL.md
+++ b/skills/frontend-test-adviser/SKILL.md
@@ -56,3 +56,60 @@ When reviewing frontend tests:
 - [ ] Mocks reset between tests (`beforeEach(() => vi.clearAllMocks())`)
 - [ ] Error and loading states covered
 - [ ] Accessibility attributes tested (role, name, disabled state)
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: RTL queries, user-event, MSW mocking, test structure.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/frontend-test-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/skills/integration-test-adviser/SKILL.md
+++ b/skills/integration-test-adviser/SKILL.md
@@ -50,3 +50,60 @@ When reviewing integration tests:
 - [ ] Both success and failure/error paths are tested
 - [ ] Tests don't depend on execution order (no shared mutable state between tests)
 - [ ] Assertions verify the actual stored/transmitted state, not just return values
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In adviser mode, focus on adapter boundaries and test slicing as described in plan tasks.
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: @AdapterIT patterns, SimulationRepository, external service mocking.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/integration-test-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/skills/unit-test-adviser/SKILL.md
+++ b/skills/unit-test-adviser/SKILL.md
@@ -93,3 +93,60 @@ Every test class should cover:
 - `assertTrue(result != null)` — use `assertThat(result).isNotNull()`.
 
 Before finalizing your review, check `gotchas.md` for common Claude mistakes in this domain.
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In adviser mode, focus on test scope and coverage gaps identified in the plan's Testing section.
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: Test structure, mocking strategies, Mother pattern, Given-When-Then.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/unit-test-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/skills/web-accessibility-adviser/SKILL.md
+++ b/skills/web-accessibility-adviser/SKILL.md
@@ -40,3 +40,60 @@ Before finalizing your review, check `gotchas.md` for common Claude mistakes in 
 - [ ] Page has a logical heading hierarchy (h1 → h2 → h3)
 - [ ] Skip navigation link provided
 - [ ] ARIA roles match the interaction model of custom widgets
+
+## Adviser Mode (SDD Orchestrator Integration)
+
+This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+
+### Entry Conditions
+Adviser mode is active when the prompt contains:
+- A `GUIDANCE CONTEXT FROM PLANNER:` block
+- A `CURRENT PLAN EXCERPT:` block
+
+### Adviser Mode Procedure
+1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
+2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
+4. Produce structured advice in the format below.
+5. Save output to engram and return summary + observation ID.
+
+Focus ONLY on your specialist domain: WCAG 2.1 AA, ARIA patterns, keyboard navigation, focus management.
+
+### Output Format (Adviser Mode)
+```
+### Strengths
+- [What looks sound in the plan from this skill's domain perspective]
+
+### Issues Found
+[Severity: Critical / Major / Minor — reference specific task IDs or section names]
+- T001: [issue description]
+
+### Recommendations
+[Specific, actionable. Reference task ID or section name for each recommendation.]
+- T001: [recommendation]
+```
+
+### Persistence (Adviser Mode)
+Save full advice output to engram:
+```
+mem_save(
+  title: "sdd/{change-name}/guidance/web-accessibility-adviser",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your full structured advice output}"
+)
+```
+If engram is unavailable, skip silently.
+
+### Return Format (Adviser Mode)
+Return a concise summary (3-5 bullet points) plus the engram observation ID:
+```
+### Summary
+- [key point 1]
+- [key point 2]
+- ...
+
+### Engram ID
+{observation_id or "unavailable"}
+```
+Do NOT return an SDD Envelope when in adviser mode.

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -114,7 +114,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 3. **Parse**: Extract all comments where `resolved` is `false` or missing.
 4. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `@sdd-planner` with the plan re-entry prompt (include the CRIT_FEEDBACK block and ask it to revise plan.md). After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round — always foreground).
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 6 (Ask the user: **Continue to implement** / **Review artifacts** / **Abort**).
+   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7 (Ask the user: **Continue to implement** / **Review artifacts** / **Abort**).
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -54,7 +54,26 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
-3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
+3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
+
+   **NEXT Step Resolution** — set the NEXT directive based on what just completed:
+   - After explore `ok`: `NEXT: plan phase -> deep interview then crit detection`
+   - After plan `ok` (pre-crit): `NEXT: plan phase -> crit detection then ask user`
+   - After plan `ok` (post-crit, approved): `NEXT: implement phase -> wave 1 batch A`
+   - After implement `ok` (more waves remaining): `NEXT: implement phase -> wave {N} batch {ID}`
+   - After implement `ok` (all waves done): `NEXT: review phase -> auto-launch review`
+   - After review: `NEXT: review phase -> post-review fix cycle`
+
+   Update `active-workflow` marker:
+   ```
+   mcp__engram__mem_save(
+     topic_key: "sdd/{change}/active-workflow",
+     type: "architecture", project: "{project}",
+     title: "sdd/{change}/active-workflow",
+     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.copilot.md. NEXT: {phase} phase -> {next step}."
+   )
+   ```
+
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
@@ -65,6 +84,11 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → Ask the user: **Continue to {next}** / **Review artifacts** / **Abort**
+
+   **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
+   - Check `crit_completed` in `.sdd/{change}/state.yaml`.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the ask above.
 
 ## Crit Plan Review Protocol
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -16,12 +16,13 @@
 
 ## Phase-to-Model Table
 
-| Phase | Skill | Model |
-|-------|-------|-------|
-| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` |
-| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` |
-| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` |
-| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` |
+| Phase | Skill | Model | Subagent Type |
+|-------|-------|-------|---------------|
+| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` | |
+| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
+| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
+| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
+| adviser | `*-adviser` | `{WORKFLOW_MODEL_ADVISER}` ⭐ | N/A — Copilot uses natural language @agent-name invocation, not Task() |
 
 ## Evaluation Gate
 
@@ -75,11 +76,24 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
    ```
 
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
-5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
-   - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
-   - If crit is NOT found: proceed to step 6 (existing flow, no behavioral change).
+5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
+   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   b. Increment `guidance_round` in state.yaml.
+   c. For each requested adviser: invoke `@{adviser-skill}` by name (e.g. `@architect-adviser`,
+      `@api-first-adviser`) with the prompt from the Copilot Adviser Invocation template in
+      `_shared/adviser-templates.md`. This is natural language @agent-name invocation — the same
+      mechanism used to invoke `@sdd-planner` and `@sdd-explorer`. Each adviser is a `.agent.md`
+      file in `.github/agents/` and loads its SKILL.md directly (no Skill() tool required).
+   d. Run advisers sequentially (Copilot has no background execution).
+      Collect each summary + engram ID before invoking the next adviser.
+   e. Invoke `@sdd-planner` with the Plan Re-entry with Guidance format (see adviser-templates.md).
+   f. After `@sdd-planner` returns: loop back to step 1.
+   - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
+6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
+   - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 7.
+   - If crit is NOT found: proceed to step 7 (existing flow, no behavioral change).
    - After non-plan phases: skip this step entirely.
-6. **Ask or auto-continue**:
+7. **Ask or auto-continue**:
    - explore `status: ok` → auto-launch plan (no ask — 99% of the time users continue immediately)
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
@@ -87,12 +101,12 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
    - Check `crit_completed` in `.sdd/{change}/state.yaml`.
-   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
-   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the ask above.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 6).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the ask in step 7.
 
 ## Crit Plan Review Protocol
 
-Triggered automatically by Post-Phase Protocol step 5 when `which crit` succeeds after a plan phase.
+Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds after a plan phase.
 
 1. **Launch**: Run `crit plan --name {change} .sdd/{change}/plan.md` as a **foreground terminal call** (blocking). Use a timeout of at least 30 minutes (1800000ms) — Crit is interactive and the user needs time to read and comment on the plan. Tell user: "Crit is open in your browser. Leave inline comments on the plan, then click Finish Review." Do NOT proceed until the call returns — it blocks until the user clicks Finish Review.
    - **If the call times out or fails**: Do NOT treat this as approval. The absence of `.crit.json` means the review was NEVER completed — NOT that it was approved with no comments. Tell the user: "Crit review was interrupted (timeout/error). Would you like to: **Retry Crit review** / **Skip Crit, review plan manually** / **Approve plan as-is**". Do NOT proceed to implement until the user explicitly approves.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -17,12 +17,13 @@
 
 ## Phase-to-Model Table
 
-| Phase | Skill | Model |
-|-------|-------|-------|
-| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` |
-| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` |
-| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` |
-| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` |
+| Phase | Skill | Model | Subagent Type |
+|-------|-------|-------|---------------|
+| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` | |
+| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
+| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
+| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
+| adviser | `*-adviser` | `{WORKFLOW_MODEL_ADVISER}` ⭐ | `general-purpose` (hardcoded) |
 
 ## Evaluation Gate
 
@@ -72,11 +73,25 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
    ```
 
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
-5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
-   - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
-   - If crit is NOT found: proceed to step 6 (existing flow, no behavioral change).
+5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
+   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   b. Increment `guidance_round` in state.yaml (for tracking only — no maximum).
+   c. Launch all advisers in parallel using the Adviser Consultation Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`. Use `run_in_background: true` for each.
+   d. Wait for all adviser background tasks to complete.
+   e. Collect the summary and engram observation ID returned by each adviser.
+      (Each adviser persists its own output to engram and returns the observation ID.)
+      If an adviser reports engram unavailable: keep its returned inline summary text for step f.
+   f. Re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`.
+      - For each adviser: include its observation ID in the GUIDANCE block (planner fetches full content via mem_get_observation).
+      - If engram unavailable for an adviser: include its inline summary text in the GUIDANCE block instead.
+   g. After sdd-plan re-entry returns envelope: loop back to step 1 (Post-Phase Protocol from start).
+   - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
+   - The guidance loop runs as many times as sdd-plan requests guidance_requested. The user controls plan quality via crit review — if during a crit iteration the planner needs more adviser input, it can request guidance again.
+6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
+   - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 7.
+   - If crit is NOT found: proceed to step 7 (existing flow, no behavioral change).
    - After non-plan phases: skip this step entirely.
-6. **Ask or auto-continue**:
+7. **Ask or auto-continue**:
    - explore `status: ok` → auto-launch plan (no ask — 99% of the time users continue immediately)
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
@@ -84,12 +99,12 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
    - Check `crit_completed` in `.sdd/{change}/state.yaml`.
-   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
-   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` above.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 6).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` in step 7.
 
 ## Crit Plan Review Protocol
 
-Triggered automatically by Post-Phase Protocol step 5 when `which crit` succeeds after a plan phase.
+Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds after a plan phase.
 
 1. **Launch**: Run `crit plan --name {change} .sdd/{change}/plan.md` in background (Bash, `run_in_background: true`). Tell user: "Crit is open in your browser. Leave inline comments on the plan, then click Finish Review."
 2. **Wait**: Do NOT proceed until the background task completes.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -113,7 +113,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 4. **Parse**: Extract all comments where `resolved` is `false` or missing.
 5. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 6 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
+   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
 

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -51,7 +51,26 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
-3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
+3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
+
+   **NEXT Step Resolution** — set the NEXT directive based on what just completed:
+   - After explore `ok`: `NEXT: plan phase -> deep interview then crit detection`
+   - After plan `ok` (pre-crit): `NEXT: plan phase -> crit detection then ask user`
+   - After plan `ok` (post-crit, approved): `NEXT: implement phase -> wave 1 batch A`
+   - After implement `ok` (more waves remaining): `NEXT: implement phase -> wave {N} batch {ID}`
+   - After implement `ok` (all waves done): `NEXT: review phase -> auto-launch review`
+   - After review: `NEXT: review phase -> post-review fix cycle`
+
+   Update `active-workflow` marker:
+   ```
+   mem_save(
+     topic_key: "sdd/{change}/active-workflow",
+     type: "architecture", project: "{project}",
+     title: "sdd/{change}/active-workflow",
+     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. NEXT: {phase} phase -> {next step}."
+   )
+   ```
+
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
@@ -62,6 +81,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
+
+   **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
+   - Check `crit_completed` in `.sdd/{change}/state.yaml`.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` above.
 
 ## Crit Plan Review Protocol
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -50,7 +50,26 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
-3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker
+3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
+
+   **NEXT Step Resolution** — set the NEXT directive based on what just completed:
+   - After explore `ok`: `NEXT: plan phase -> deep interview then crit detection`
+   - After plan `ok` (pre-crit): `NEXT: plan phase -> crit detection then ask user`
+   - After plan `ok` (post-crit, approved): `NEXT: implement phase -> wave 1 batch A`
+   - After implement `ok` (more waves remaining): `NEXT: implement phase -> wave {N} batch {ID}`
+   - After implement `ok` (all waves done): `NEXT: review phase -> auto-launch review`
+   - After review: `NEXT: review phase -> post-review fix cycle`
+
+   Update `active-workflow` marker:
+   ```
+   mem_save(
+     topic_key: "sdd/{change}/active-workflow",
+     type: "architecture", project: "{project}",
+     title: "sdd/{change}/active-workflow",
+     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. NEXT: {phase} phase -> {next step}."
+   )
+   ```
+
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
@@ -61,6 +80,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
+
+   **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
+   - Check `crit_completed` in `.sdd/{change}/state.yaml`.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` above.
 
 ## Crit Plan Review Protocol
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -16,12 +16,13 @@
 
 ## Phase-to-Model Table
 
-| Phase | Skill | Model |
-|-------|-------|-------|
-| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` |
-| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` |
-| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` |
-| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` |
+| Phase | Skill | Model | Subagent Type |
+|-------|-------|-------|---------------|
+| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` | |
+| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
+| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
+| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
+| adviser | `*-adviser` | `{WORKFLOW_MODEL_ADVISER}` ⭐ | `general-purpose` (hardcoded) |
 
 ## Evaluation Gate
 
@@ -71,11 +72,20 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
    ```
 
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
-5. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
-   - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 6.
-   - If crit is NOT found: proceed to step 6 (existing flow, no behavioral change).
+5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
+   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   b. Increment `guidance_round` in state.yaml.
+   c. **Launch advisers sequentially** (OpenCode does not support run_in_background) using the
+      Sequential Adviser Consultation Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`.
+      Run one adviser at a time; collect each summary + engram ID before launching the next.
+   d. After all advisers complete: re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`.
+   e. After sdd-plan re-entry returns envelope: loop back to step 1 (Post-Phase Protocol from start).
+   - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
+6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
+   - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 7.
+   - If crit is NOT found: proceed to step 7 (existing flow, no behavioral change).
    - After non-plan phases: skip this step entirely.
-6. **Ask or auto-continue**:
+7. **Ask or auto-continue**:
    - explore `status: ok` → auto-launch plan (no ask — 99% of the time users continue immediately)
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
    - implement `status: ok` → auto-launch review (no ask)
@@ -83,12 +93,12 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
    - Check `crit_completed` in `.sdd/{change}/state.yaml`.
-   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 5).
-   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` above.
+   - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 6).
+   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` in step 7.
 
 ## Crit Plan Review Protocol
 
-Triggered automatically by Post-Phase Protocol step 5 when `which crit` succeeds after a plan phase.
+Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds after a plan phase.
 
 1. **Launch**: Run `crit plan --name {change} .sdd/{change}/plan.md` as a **foreground Bash call** (blocking — do NOT use `run_in_background`). Use a timeout of at least 30 minutes (1800000ms) — Crit is interactive and the user needs time to read and comment on the plan. Tell user: "Crit is open in your browser. Leave inline comments on the plan, then click Finish Review." Do NOT proceed until the Bash call returns — it blocks until the user clicks Finish Review.
    - **If the Bash call times out or fails**: Do NOT treat this as approval. The absence of `.crit.json` means the review was NEVER completed — NOT that it was approved with no comments. Tell the user: "Crit review was interrupted (timeout/error). Would you like to: **Retry Crit review** / **Skip Crit, review plan manually** / **Approve plan as-is**". Do NOT proceed to implement until the user explicitly approves.

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -106,7 +106,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 3. **Parse**: Extract all comments where `resolved` is `false` or missing.
 4. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round — always foreground).
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 6 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
+   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
 

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -53,6 +53,8 @@ After compaction, if memory has `sdd/*/active-workflow` observations starting wi
 
 1. Re-read `{WORKFLOW_DIR}/ORCHESTRATOR.md` and its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
-3. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
+3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
+4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.
+5. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
 
 If no `active-workflow` marker is found, do nothing.

--- a/workflows/sdd/_shared/adviser-templates.md
+++ b/workflows/sdd/_shared/adviser-templates.md
@@ -23,7 +23,7 @@ Task(
   Skill(skill: "{adviser-skill}", args: "{change-name}")
 
   If the Skill tool fails, fall back to reading the SKILL.md file directly:
-  Read("{skills_path}/skills/{adviser-skill}/SKILL.md")
+  Read("{SKILLS_PATH}/skills/{adviser-skill}/SKILL.md")
   (e.g. for Codex/Copilot where Skill() is unavailable — reading the file gives the same instructions)
   If neither Skill() nor the file read succeeds, use your built-in domain knowledge for this adviser role.
 
@@ -100,7 +100,7 @@ Run each adviser sequentially. Wait for each to return before launching the next
 Invoke each requested adviser by naming it in your message:
 ```
 @{adviser-skill} You are a specialist adviser. Load your skill by reading:
-{WORKFLOW_DIR}/../skills/{adviser-skill}/SKILL.md
+{SKILLS_PATH}/{adviser-skill}/SKILL.md
 
 GUIDANCE CONTEXT FROM PLANNER:
 {guidance_context from envelope}

--- a/workflows/sdd/_shared/adviser-templates.md
+++ b/workflows/sdd/_shared/adviser-templates.md
@@ -34,11 +34,14 @@ Task(
   GUIDANCE CONTEXT FROM PLANNER:
   {guidance_context from envelope}
 
-  CURRENT PLAN EXCERPT:
-  {paste relevant sections from .sdd/{change-name}/plan.md}
+  PLAN:
+  Read the full plan at: .sdd/{change-name}/plan.md
+  Focus your analysis on the sections relevant to your domain, but consider the full
+  architecture context — cross-section dependencies matter. The guidance_context above
+  tells you WHERE to focus; the plan gives you the FULL picture.
 
   TASK:
-  Analyse the plan above from your specialist domain perspective.
+  Read the plan file first, then analyse from your specialist domain perspective.
   Provide structured advice in this format:
 
   ### Strengths
@@ -105,8 +108,9 @@ Invoke each requested adviser by naming it in your message:
 GUIDANCE CONTEXT FROM PLANNER:
 {guidance_context from envelope}
 
-CURRENT PLAN EXCERPT:
-{paste relevant sections from .sdd/{change-name}/plan.md}
+PLAN:
+Read the full plan at: .sdd/{change-name}/plan.md
+Focus on sections relevant to your domain; the guidance_context tells you WHERE to focus.
 
 Provide advice in Strengths / Issues Found / Recommendations format.
 Save to engram if available. Return summary + engram ID.

--- a/workflows/sdd/_shared/adviser-templates.md
+++ b/workflows/sdd/_shared/adviser-templates.md
@@ -1,0 +1,162 @@
+# SDD Adviser Templates
+
+These templates are used by the orchestrator when handling `guidance_requested` envelopes.
+See `launch-templates.md` for phase launch templates (explore, plan, implement, review).
+
+## Adviser Consultation Template
+
+> **Multi-agent compatibility note**: This template is for Claude and Factory agents (Task() + run_in_background supported).
+> OpenCode: use the Sequential Adviser Template below (run_in_background: false, one at a time).
+> Copilot: use the Copilot Adviser Invocation section below (@agent-name pattern, no Task() tool).
+> Codex: same template as Claude/Factory — Task() is supported; run_in_background: false (no background support).
+
+Use this template for each adviser when the orchestrator handles a `guidance_requested` envelope.
+Launch all requested advisers in parallel (run_in_background: true).
+
+Task(
+  description: 'adviser consultation ({adviser-skill}) for {change-name}',
+  subagent_type: 'general-purpose',    // hardcoded — advisers are always general-purpose Task() calls
+  model: '{WORKFLOW_MODEL_ADVISER}',
+  run_in_background: true,
+  prompt: 'You are a specialist adviser sub-agent. Load your skill:
+
+  Skill(skill: "{adviser-skill}", args: "{change-name}")
+
+  If the Skill tool fails, fall back to reading the SKILL.md file directly:
+  Read("{skills_path}/skills/{adviser-skill}/SKILL.md")
+  (e.g. for Codex/Copilot where Skill() is unavailable — reading the file gives the same instructions)
+  If neither Skill() nor the file read succeeds, use your built-in domain knowledge for this adviser role.
+
+  CONTEXT:
+  - Change: {change-name}
+  - Project: {project path}
+
+  GUIDANCE CONTEXT FROM PLANNER:
+  {guidance_context from envelope}
+
+  CURRENT PLAN EXCERPT:
+  {paste relevant sections from .sdd/{change-name}/plan.md}
+
+  TASK:
+  Analyse the plan above from your specialist domain perspective.
+  Provide structured advice in this format:
+
+  ### Strengths
+  [What looks good in the current plan]
+
+  ### Issues Found
+  [Problems with severity: Critical / Major / Minor. Be specific — reference file paths and section names.]
+
+  ### Recommendations
+  [Specific actionable suggestions. Each recommendation should reference a plan task ID or section.]
+
+  PERSISTENCE:
+  Save your full advice output to engram:
+  mem_save(
+    title: "sdd/{change-name}/guidance/{adviser-skill}",
+    type: "architecture",
+    project: "{project-name}",
+    content: "{your full structured advice output}"
+  )
+  If engram is unavailable, skip saving silently.
+
+  RETURN FORMAT:
+  Return a short summary of your advice (3-5 bullet points) plus the engram observation ID (if saved).
+  Format:
+  ### Summary
+  - ...key points...
+  ### Engram ID
+  {observation_id or "unavailable"}
+
+  Do NOT produce an SDD Envelope.'
+)
+
+## Sequential Adviser Consultation Template (OpenCode / Codex)
+
+> Use this template instead of the parallel template above when `run_in_background` is NOT supported
+> (OpenCode, Codex). Launch advisers one at a time, foreground.
+
+Task(
+  description: 'adviser consultation ({adviser-skill}) for {change-name}',
+  subagent_type: 'general-purpose',
+  model: '{WORKFLOW_MODEL_ADVISER}',
+  run_in_background: false,   // OpenCode/Codex: foreground only
+  prompt: '...same prompt body as parallel template above...'
+)
+
+Run each adviser sequentially. Wait for each to return before launching the next.
+
+## Copilot Adviser Invocation
+
+> Copilot has no Task() tool. Use natural language @agent-name invocations instead — exactly the same
+> mechanism the orchestrator uses to invoke `@sdd-planner` and `@sdd-explorer`.
+>
+> **Why @agent-name (not #runSubagent)**: `#runSubagent` is VS Code-specific and less portable.
+> Natural language `@agent-name` invocation is the standard Copilot subagent mechanism and matches
+> the existing SDD phase pattern. Each adviser is a `.agent.md` file in `.github/agents/`.
+>
+> Invoke advisers sequentially (no background execution in Copilot).
+
+Invoke each requested adviser by naming it in your message:
+```
+@{adviser-skill} You are a specialist adviser. Load your skill by reading:
+{WORKFLOW_DIR}/../skills/{adviser-skill}/SKILL.md
+
+GUIDANCE CONTEXT FROM PLANNER:
+{guidance_context from envelope}
+
+CURRENT PLAN EXCERPT:
+{paste relevant sections from .sdd/{change-name}/plan.md}
+
+Provide advice in Strengths / Issues Found / Recommendations format.
+Save to engram if available. Return summary + engram ID.
+```
+Example invocations: `@architect-adviser`, `@api-first-adviser`, `@unit-test-adviser`, etc.
+Each `.agent.md` configures the agent to read its own SKILL.md — no fallback to a generic agent needed.
+
+---
+
+## Plan Phase: Re-entry with Guidance Template
+
+When the orchestrator re-enters `sdd-plan` after collecting adviser guidance:
+
+Task(
+  description: 'plan re-entry (guidance round {N}) for {change-name}',
+  subagent_type: '{WORKFLOW_SUBAGENT_PLANNER}',
+  model: '{WORKFLOW_MODEL_PLANNER}',
+  run_in_background: false,
+  prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading your phase instructions via the Skill tool:
+
+  Skill(skill: "sdd-plan", args: "{change-name}")
+
+  If the Skill tool fails, fall back to reading {project path}/{SKILLS_PATH}/sdd-plan/SKILL.md directly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact directory: .sdd/{change-name}/
+  - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
+
+  GUIDANCE (Round {N}):
+  Adviser recommendations collected by orchestrator. For each entry below, fetch full content via
+  mem_get_observation(id) if an ID is provided, or read the inline text directly if no ID.
+
+  {for each adviser:}
+  ### {adviser-skill} (engram ID: {observation_id or "inline"})
+  {if inline: paste adviser output directly}
+  {if ID: "Fetch via mem_get_observation({observation_id})"}
+
+  TASK:
+  Integrate the adviser recommendations into plan.md.
+  For each recommendation:
+  1. Assess whether it applies (some may not fit scope)
+  2. If it applies: update the relevant task, add/modify Detail Block, adjust Before/After, or add a new task
+  3. Document integration in ## Advice Received section
+  Skip the Deep Interview, Team Selection, and Guidance Request steps (already completed).
+  Re-run the Detail Quality Gate.
+  Return the SDD Envelope with status: ok (or warning if recommendations could not be fully integrated).
+
+  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
+
+  IMPORTANT: Your LAST output MUST be the SDD Envelope per _shared/envelope-contract.md.'
+)

--- a/workflows/sdd/_shared/envelope-contract.md
+++ b/workflows/sdd/_shared/envelope-contract.md
@@ -14,6 +14,7 @@ Every SDD skill (explore, plan, implement, review) MUST return the SDD Envelope 
 |--------|---------|
 | `ok` | Phase completed successfully |
 | `warning` | Completed, but with concerns that need attention |
+| `guidance_requested` | Plan phase completed; adviser consultation required before finalizing. Orchestrator must launch advisers and re-enter plan with guidance. |
 | `blocked` | Cannot proceed -- missing input, unresolved dependency, or ambiguity |
 | `failed` | Error during execution |
 
@@ -28,10 +29,12 @@ Copy this block and fill it in as the last output of your skill:
 
 | Field | Value |
 |-------|-------|
-| **Status** | ok / warning / blocked / failed |
+| **Status** | ok / warning / guidance_requested / blocked / failed |
 | **Phase** | explore / plan / implement / review |
 | **Change** | {change-name} |
 | **Engram Ref** | _(optional)_ observation ID from `mem_save`, or omit if engram not used |
+| **Requested Advisers** | _(only when status=guidance_requested)_ comma-separated adviser skill names, e.g. `architect-adviser, api-first-adviser` |
+| **Guidance Context** | _(only when status=guidance_requested)_ 1-3 paragraph summary of what advisers should review: key design decisions, tradeoffs, uncertainties |
 
 ### Executive Summary
 2-4 sentences. What was done, key decisions made, and outcomes. Must be enough for someone to decide whether to proceed without reading the full artifacts.
@@ -48,4 +51,6 @@ Copy this block and fill it in as the last output of your skill:
 - {Risk description, or "None"}
 ```
 
-> **When to include Engram Ref:** Include `engram_ref` only if you successfully persisted an artifact to engram during this phase. The orchestrator uses this ID for fast recovery (skips the search step).
+> **When to include Engram Ref:** Include only if you successfully persisted an artifact to engram during this phase. The orchestrator uses this ID for fast recovery.
+>
+> **When to include Requested Advisers / Guidance Context:** Include only when returning `status: guidance_requested`. The orchestrator reads these fields to launch adviser consultations.

--- a/workflows/sdd/hooks/sdd-hooks-claude.json
+++ b/workflows/sdd/hooks/sdd-hooks-claude.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sdd-pre-compact.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sdd-session-compact.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/workflows/sdd/hooks/sdd-hooks-factory.json
+++ b/workflows/sdd/hooks/sdd-hooks-factory.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "PreCompact": [{
+      "type": "command",
+      "command": "\"$FACTORY_PROJECT_DIR\"/.factory/hooks/sdd-pre-compact.sh"
+    }]
+  }
+}

--- a/workflows/sdd/hooks/sdd-pre-compact.sh
+++ b/workflows/sdd/hooks/sdd-pre-compact.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # SDD Pre-Compaction Hook
 # Ensures .sdd/ state is persisted before context compaction.
-for state_file in .sdd/*/state.yaml; do
-  [ -f "$state_file" ] || continue
+# Searches root and one level of subdirectories for .sdd/*/state.yaml.
+find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read -r state_file; do
   change_name="$(basename "$(dirname "$state_file")")"
   touch "$state_file"
   echo "[sdd-hook] Pre-compaction: verified state for $change_name"

--- a/workflows/sdd/hooks/sdd-pre-compact.sh
+++ b/workflows/sdd/hooks/sdd-pre-compact.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SDD Pre-Compaction Hook
+# Ensures .sdd/ state is persisted before context compaction.
+for state_file in .sdd/*/state.yaml; do
+  [ -f "$state_file" ] || continue
+  change_name="$(basename "$(dirname "$state_file")")"
+  touch "$state_file"
+  echo "[sdd-hook] Pre-compaction: verified state for $change_name"
+done

--- a/workflows/sdd/hooks/sdd-session-compact.sh
+++ b/workflows/sdd/hooks/sdd-session-compact.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 # SDD SessionStart(compact) Hook (Tier 1a — Claude only)
 # Fires when Claude resumes after compaction. Stdout becomes visible context.
-for state_file in .sdd/*/state.yaml; do
-  [ -f "$state_file" ] || continue
+# Searches root and one level of subdirectories for .sdd/*/state.yaml.
+find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read -r state_file; do
   change_name="$(basename "$(dirname "$state_file")")"
   current_phase="$(grep '^current_phase:' "$state_file" | sed 's/current_phase: *//')"
   next_step="$(grep '^next_step:' "$state_file" | sed 's/next_step: *//')"
   [ -z "$current_phase" ] && current_phase="unknown"
   [ -z "$next_step" ] && next_step="check state.yaml for details"
   echo "CRITICAL: SDD workflow was active during compaction. You MUST run compaction recovery NOW."
-  echo "Read .sdd/${change_name}/state.yaml and check engram for active-workflow marker."
+  echo "Read ${state_file} and check engram for active-workflow marker."
   echo "Load Skill(sdd-orchestrator) and resume from the NEXT directive in the marker."
   echo "Current phase: ${current_phase}. NEXT: ${next_step}."
 done

--- a/workflows/sdd/hooks/sdd-session-compact.sh
+++ b/workflows/sdd/hooks/sdd-session-compact.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# SDD SessionStart(compact) Hook (Tier 1a — Claude only)
+# Fires when Claude resumes after compaction. Stdout becomes visible context.
+for state_file in .sdd/*/state.yaml; do
+  [ -f "$state_file" ] || continue
+  change_name="$(basename "$(dirname "$state_file")")"
+  current_phase="$(grep '^current_phase:' "$state_file" | sed 's/current_phase: *//')"
+  next_step="$(grep '^next_step:' "$state_file" | sed 's/next_step: *//')"
+  [ -z "$current_phase" ] && current_phase="unknown"
+  [ -z "$next_step" ] && next_step="check state.yaml for details"
+  echo "CRITICAL: SDD workflow was active during compaction. You MUST run compaction recovery NOW."
+  echo "Read .sdd/${change_name}/state.yaml and check engram for active-workflow marker."
+  echo "Load Skill(sdd-orchestrator) and resume from the NEXT directive in the marker."
+  echo "Current phase: ${current_phase}. NEXT: ${next_step}."
+done

--- a/workflows/sdd/plugins/sdd-compaction.ts
+++ b/workflows/sdd/plugins/sdd-compaction.ts
@@ -1,0 +1,42 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import type { Plugin } from "@opencode-ai/plugin";
+
+export const SddCompaction: Plugin = async (_ctx) => {
+  return {
+    "experimental.session.compacting": async (
+      _input: unknown,
+      output: { context: { push: (s: string) => void } }
+    ) => {
+      const sddDir = ".sdd";
+      if (!existsSync(sddDir)) return;
+      const changes = readdirSync(sddDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .filter((d) => existsSync(join(sddDir, d.name, "state.yaml")));
+      if (changes.length === 0) return;
+      for (const c of changes) {
+        const stateFile = join(sddDir, c.name, "state.yaml");
+        const stateContent = readFileSync(stateFile, "utf-8");
+        const phaseMatch = stateContent.match(/^current_phase:\s*(.+)$/m);
+        const nextMatch = stateContent.match(/^next_step:\s*(.+)$/m);
+        const currentPhase = phaseMatch?.[1] ?? "unknown";
+        const nextStep = nextMatch?.[1] ?? "check state.yaml";
+        output.context.push(`## SDD Workflow Recovery (CRITICAL)
+ACTIVE SDD workflow: ${c.name}
+Current phase: ${currentPhase}
+NEXT: ${nextStep}
+
+You MUST run compaction recovery NOW:
+1. Read .sdd/${c.name}/state.yaml for full state
+2. Check engram for active-workflow marker (mem_context)
+3. Load Skill(sdd-orchestrator) and resume from NEXT directive
+
+Full state.yaml content:
+\`\`\`yaml
+${stateContent}
+\`\`\`
+`);
+      }
+    },
+  };
+};

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -16,6 +16,13 @@ You are a senior software architect specializing in code design and implementati
    2. `mem_get_observation(id: {observation-id})` → full, untruncated exploration summary (REQUIRED — always follow search with get)
       Use this recovered content as your exploration context. If neither file nor engram has the exploration, return envelope with `status: blocked` and explain the missing dependency.
 
+## Re-entry Paths (MANDATORY — check BEFORE proceeding to main flow)
+
+   **Crit Re-entry**: If `CRIT_FEEDBACK:` block found in launch prompt → follow Crit Feedback Re-entry steps below.
+   **Guidance Re-entry**: If `GUIDANCE:` block found in launch prompt → go to step 8 (Guidance Integration).
+
+   If neither block is present → proceed with main flow from step 1.
+
    **Crit Feedback Re-entry**: If the launch prompt contains a `CRIT_FEEDBACK:` block:
    1. Read the existing `.sdd/{change}/plan.md` (do NOT start from scratch)
    2. For each unresolved comment in the CRIT_FEEDBACK block:
@@ -23,7 +30,7 @@ You are a senior software architect specializing in code design and implementati
       b. Revise the plan to address the feedback
       c. Reply to the comment: `crit comment --plan {change} --reply-to {id} --author 'Claude Code' '<what was changed>'`
    3. Skip the Deep Interview (already completed in the initial plan pass)
-   4. Skip Team Selection and Advice Phase (already completed)
+   4. Skip Team Selection and Guidance Request step (already completed)
    5. Re-run the Detail Quality Gate on the revised plan
    6. Update plan status and return envelope
 
@@ -49,13 +56,18 @@ You are a senior software architect specializing in code design and implementati
    - Do NOT proceed to step 4 until the interview loop has completed
 
 4. Analyze the requested changes and break them down into clear, actionable steps
-5. Team Selection (parallel execution if possible)
+5. Team Selection (record which advisers are needed — do NOT invoke yet)
 
    **Specialist Skills for Planning Advice:**
 
    <!-- ADVISER_TABLE_PLACEHOLDER -->
 
-   If no adviser skills are listed above, skip steps 5 and 7 (Team Selection and Advice Phase) and proceed directly to step 6 (Implementation Plan).
+   If no adviser skills are listed above, skip steps 5 and 7 (Team Selection and Guidance Request) and proceed directly to step 6 (Implementation Plan).
+
+   Review the feature requirements and identify which specialist skills are relevant.
+   Record selections in `## Team Selection` section with reasoning.
+   These selections will be returned in the envelope at step 7 if guidance is needed.
+   Do NOT invoke Task() or Skill() for advisers here — that is handled by the orchestrator.
 
    **Selection Process:**
    1. Analyze the feature requirements from exploration.md
@@ -108,7 +120,7 @@ You are a senior software architect specializing in code design and implementati
 
    **Detail Quality Gate (MANDATORY — self-check before proceeding to step 7)**:
 
-   Before proceeding to the Advice Phase, verify your plan meets the detail quality bar:
+   Before proceeding to the Guidance Request step, verify your plan meets the detail quality bar:
 
    1. **Task Detail Blocks**: Every non-trivial task has a `**Details for TXXX**:` block immediately after the task line. Trivial tasks (renaming, import-only, config toggle) may omit it. When in doubt, include it.
    2. **Contract Specifications**: If the plan introduces new types, interfaces, or data schemas, Section 2 must have a populated "Contract Specifications" subsection with exact signatures in code blocks.
@@ -118,36 +130,47 @@ You are a senior software architect specializing in code design and implementati
    If any check fails, go back and add the missing detail before continuing.
    The implementer (a different model with no memory of this session) depends entirely on plan.md for design decisions.
 
-7. Advice Phase (MANDATORY when skills were selected in step 5)
+7. Guidance Request (MANDATORY when advisers are needed)
 
-   **How to invoke skills** - Use the Task tool to spawn advisor subagents:
+   **When to request guidance:**
+   After the Detail Quality Gate (step 6), if the plan has areas of architectural uncertainty, cross-layer complexity, or design decisions that benefit from specialist review: return envelope with `status: guidance_requested`.
 
-   For each selected skill, spawn a subagent that:
-   1. Loads the skill using the Skill tool
-   2. Analyzes the plan context you provide
-   3. Returns structured advice
+   **How to decide if guidance is needed:**
+   - Plan touches 3+ layers (domain + infra + API) → request `architect-adviser`
+   - Plan introduces new API contracts or REST endpoints → request `api-first-adviser`
+   - Plan has frontend component changes → request `component-adviser`
+   - Simple single-layer changes → no guidance needed; return `status: ok` directly
 
-   **Task invocation pattern:**
-   ```json
-   {
-     "description": "Get {skill-name} advice",
-     "prompt": "You are a specialist advisor. First, load the {skill-name} skill using the Skill tool. Then analyze the following context and provide structured advice:\n\n## Plan Context\n{paste relevant sections from exploration.md and current plan}\n\n## What I Need Advice On\n{specific questions or areas needing review}\n\nProvide your advice in this format:\n### Strengths\n[What looks good]\n### Issues Found\n[Problems with severity: Critical/Major/Minor]\n### Recommendations\n[Specific actionable suggestions]",
-     "subagent_type": "general-purpose"
-   }
-   ```
+   **What to include in the envelope:**
+   - `requested_advisers`: comma-separated list of adviser skill names
+   - `guidance_context`: 2-4 sentence summary of what the advisers should focus on (specific tasks, tradeoffs, or design decisions)
 
-   **Example invocations** (use the actual skill names from the table above):
-   - `description: "Get {adviser-skill-name} advice"`, `prompt: "Load {adviser-skill-name} skill... [context about the relevant domain]"`
-   - When multiple advisers are selected, invoke them in parallel (see below)
+   **When NOT to request guidance:**
+   - When re-entered with a `GUIDANCE:` block (guidance already collected — skip to step 8)
+   - When re-entered with a `CRIT_FEEDBACK:` block (crit cycle — skip all advice logic)
+   - When the change is small-scope (≤3 files, single layer)
 
-   **Parallel execution:**
-   If multiple skills are needed, invoke them in parallel by including multiple Task tool calls in a single message. Each subagent runs in its own isolated context.
+8. Guidance Integration Re-entry (TRIGGERED when `GUIDANCE:` block found in launch prompt)
 
-   **Integration (NOT OPTIONAL):**
-   1. Wait for all Task subagents to complete
-   2. Read each subagent's returned advice
-   3. Update the plan incorporating relevant recommendations
-   4. Document advice received under `## Advice Received` section in the plan
+   When re-launched by the orchestrator with a `GUIDANCE:` block in the prompt:
+
+   1. Detect: check if the launch prompt contains `GUIDANCE (Round N):` block.
+   2. Read existing plan.md (do NOT start from scratch — revise only).
+   3. For each adviser entry in GUIDANCE block:
+      a. If entry has `engram ID`: call `mem_get_observation(id)` to fetch full advice.
+      b. If entry is inline text: read directly.
+      c. Assess each recommendation: relevant to scope? affects task quality?
+      d. Integrate applicable recommendations:
+         - Update task Detail Blocks with revised signatures or schemas
+         - Add new tasks if a critical gap was identified
+         - Revise Before/After Analysis if architecture patterns changed
+         - Update Section 2 Contract Specifications if new interfaces emerged
+   4. Update `## Advice Received` section: document what was integrated and what was skipped (with rationale).
+   5. Re-run Detail Quality Gate (step 6 checks).
+   6. Return `status: ok` envelope (or `warning` if recommendations could not be fully integrated).
+
+   **Skips**: Deep Interview, Team Selection, Guidance Request step (already done).
+   **NEVER** return `status: guidance_requested` from a guidance re-entry (prevents infinite loop).
 
 **For each change**:
 - Describe the exact location in the code where changes are needed
@@ -258,7 +281,7 @@ After completing the plan and updating the status to "Complete", your **LAST out
 See [envelope contract](../_shared/envelope-contract.md) for format.
 
 **Phase-specific guidance:**
-- **Status**: `ok` — plan completed with all sections filled and interview done
+- **Status**: `ok` — plan completed with all sections filled and interview done; OR `guidance_requested` — plan draft complete but adviser consultation needed (include `requested_advisers` and `guidance_context` fields)
 - **Phase**: `plan`
 - **Change**: use the `{change-name}` from this session
 - **Artifacts**: include the plan file path `.sdd/{change-name}/plan.md`
@@ -309,8 +332,8 @@ See [envelope contract](../_shared/envelope-contract.md) for format.
 - 🚫 **Missing Before/After for modification tasks** — any task that modifies existing code MUST include before/after state in Section 2's Before/After Analysis. The implementer cannot reverse-engineer the current state from a one-line description.
 - 🚫 **Empty Contract Specifications** — when the plan introduces new types, interfaces, or data schemas, the Contract Specifications subsection in Section 2 MUST list them with exact signatures. Omitting this forces the implementer to invent type definitions.
 - 🚫 **Writing entire plan in one operation** — use incremental Edit calls
-- 🚫 **Skipping advice phase** — always consult subagents when uncertain
-- 🚫 **Not updating plan after advice** — integrate all feedback received
+- 🚫 **Skipping guidance request** — always request adviser guidance when the plan has cross-layer complexity or architectural uncertainty
+- 🚫 **Not integrating guidance** — when re-entered with a GUIDANCE block, always integrate applicable adviser recommendations into the plan before returning ok
 - 🚫 **Proposing implementation code** — plan describes WHAT to build (including type signatures, schemas, and interface contracts) but does NOT include full function implementations. Short code snippets showing signatures and structure are expected; complete method bodies are not
 - 🚫 **Ignoring risks section** — always document potential issues and mitigations
 - 🚫 **Omitting test scope from the plan** — always identify required unit and integration tests, even if test code is written in a later phase

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -30,9 +30,13 @@ You are a senior software architect specializing in code design and implementati
       b. Revise the plan to address the feedback
       c. Reply to the comment: `crit comment --plan {change} --reply-to {id} --author 'Claude Code' '<what was changed>'`
    3. Skip the Deep Interview (already completed in the initial plan pass)
-   4. Skip Team Selection and Guidance Request step (already completed)
+   4. Re-evaluate Team Selection: if the crit feedback introduces new concerns that
+      would benefit from specialist review (e.g. "get architect input on this pattern",
+      "testing strategy needs review"), update the `## Team Selection` section.
    5. Re-run the Detail Quality Gate on the revised plan
-   6. Update plan status and return envelope
+   6. If Team Selection added new advisers in step 4 → return `status: guidance_requested`
+      (same as step 7 — orchestrator will launch advisers and re-enter with guidance).
+      If no new advisers needed → return `status: ok` envelope.
 
    The `Bash` tool with `crit comment --plan` is required for replying. `Bash(crit:*)` is included in allowed-tools for this purpose.
 
@@ -130,25 +134,19 @@ You are a senior software architect specializing in code design and implementati
    If any check fails, go back and add the missing detail before continuing.
    The implementer (a different model with no memory of this session) depends entirely on plan.md for design decisions.
 
-7. Guidance Request (MANDATORY when advisers are needed)
+7. Guidance Request
 
-   **When to request guidance:**
-   After the Detail Quality Gate (step 6), if the plan has areas of architectural uncertainty, cross-layer complexity, or design decisions that benefit from specialist review: return envelope with `status: guidance_requested`.
+   **Rule: if Team Selection (step 5) selected any advisers → return `guidance_requested`.**
 
-   **How to decide if guidance is needed:**
-   - Plan touches 3+ layers (domain + infra + API) → request `architect-adviser`
-   - Plan introduces new API contracts or REST endpoints → request `api-first-adviser`
-   - Plan has frontend component changes → request `component-adviser`
-   - Simple single-layer changes → no guidance needed; return `status: ok` directly
+   This is the ONLY condition. If step 5 identified advisers, you MUST request guidance — do not second-guess the selection. If step 5 selected zero advisers, return `status: ok` directly.
 
    **What to include in the envelope:**
-   - `requested_advisers`: comma-separated list of adviser skill names
-   - `guidance_context`: 2-4 sentence summary of what the advisers should focus on (specific tasks, tradeoffs, or design decisions)
+   - `requested_advisers`: comma-separated list of ALL adviser skill names selected in step 5
+   - `guidance_context`: for EACH requested adviser, 1-2 sentences describing what they should focus on. Be specific — reference task IDs, section names, or design decisions from the plan.
 
    **When NOT to request guidance:**
    - When re-entered with a `GUIDANCE:` block (guidance already collected — skip to step 8)
-   - When re-entered with a `CRIT_FEEDBACK:` block (crit cycle — skip all advice logic)
-   - When the change is small-scope (≤3 files, single layer)
+   - When step 5 selected zero advisers
 
 8. Guidance Integration Re-entry (TRIGGERED when `GUIDANCE:` block found in launch prompt)
 

--- a/workflows/sdd/sdd-plan/templates/plan_template.md
+++ b/workflows/sdd/sdd-plan/templates/plan_template.md
@@ -63,7 +63,10 @@ This prevents the implementer from having to reverse-engineer the current state.
 ## Team Selection
 
 <!--
-Skills selected for advice during planning phase.
+Adviser skills identified during planning. These are NOT invoked by sdd-plan directly.
+If guidance is needed, sdd-plan returns a guidance_requested envelope listing these skills.
+The orchestrator then launches each adviser, collects guidance, and re-enters sdd-plan
+with the recommendations. See SKILL.md steps 5, 7, and 8 for the full flow.
 -->
 
 | Skill | Reason for Selection |
@@ -73,11 +76,13 @@ Skills selected for advice during planning phase.
 ## Advice Received
 
 <!--
-Document key recommendations from each skill consulted.
-This section is populated during the Advice phase (step 6).
+Adviser recommendations integrated into the plan. This section is populated during
+Guidance Integration re-entry (step 8) — after the orchestrator collects adviser
+outputs and re-launches sdd-plan with a GUIDANCE block.
+For each adviser: document what was integrated and what was skipped (with rationale).
 -->
 
-_No advice received yet. Skills will be invoked after team selection._
+_No advice received yet. Advisers will be consulted by the orchestrator if guidance is requested._
 
 ## 3. Implementation Tasks
 

--- a/workflows/sdd/workflow.yaml
+++ b/workflows/sdd/workflow.yaml
@@ -77,5 +77,13 @@ components:
     - "Bash(git status:*)"
     - "Skill(git-commit)"
     - "Skill(git-pull-request)"
+  hooks:
+    agents:
+      claude:
+        - definition: hooks/sdd-hooks-claude.json
+      factory:
+        - definition: hooks/sdd-hooks-factory.json
+      opencode:
+        - definition: plugins/sdd-compaction.ts
   gitignore:
     - ".sdd/"

--- a/workflows/sdd/workflow.yaml
+++ b/workflows/sdd/workflow.yaml
@@ -31,6 +31,10 @@ components:
       model: opus
     - name: sdd-orchestrator
       kind: orchestrator
+    - name: sdd-adviser
+      kind: subagent
+      skill: "*-adviser"
+      model: opus
   decisionRules:
     - scenario: '"commit", "commit my changes", "create commit"'
       resolution: "Use `git-commit`"


### PR DESCRIPTION
## Summary

Implement Anthropic's Advisor Strategy pattern in the SDD workflow. Instead of sdd-plan spawning advisers inline, the orchestrator drives an adviser consultation loop:

1. sdd-plan (Sonnet executor) plans, identifies guidance needs, returns `guidance_requested` envelope
2. Orchestrator launches adviser Task() calls with `{WORKFLOW_MODEL_ADVISER}` (e.g. Opus)
3. Advisers save structured advice to engram, return summary + observation ID
4. Orchestrator re-launches sdd-plan with GUIDANCE block containing observation IDs
5. sdd-plan integrates adviser recommendations into plan.md

## Changes

- **Envelope**: `guidance_requested` status with Requested Advisers and Guidance Context fields
- **Orchestrator** (3 variants): guidance_requested branch in Post-Phase Protocol, adviser row in Phase-to-Model Table
- **sdd-plan**: Step 7 replaced with Guidance Request, Step 8 added for Guidance Integration re-entry
- **adviser-templates.md**: New file with 4 templates (parallel, sequential, Copilot, plan re-entry)
- **workflow.yaml**: `sdd-adviser` role with `model: opus`
- **7 adviser skills**: Adviser Mode section (structured output, engram persistence)

## Test plan

- [x] All 3 ORCHESTRATOR variants have consistent guidance_requested branch
- [x] sdd-plan SKILL.md has both re-entry paths (CRIT_FEEDBACK + GUIDANCE)
- [x] `devrune install` resolves `{WORKFLOW_MODEL_ADVISER}` placeholder
- [x] TUI shows "Adviser" row in model selection
- [x] Copilot generates `.agent.md` wrappers for all 7 advisers

🤖 Generated with [Claude Code](https://claude.com/claude-code)