### PR TITLE
feat(skills): enrich git-commit and git-pull-request with full workflow

### DIFF
--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,56 +1,451 @@
 ---
 name: git-commit
-description: "Automate git commits following Conventional Commits with JIRA ticket integration."
+description: 'Use when the user asks to create/make/save a commit in ANY language (English/Spanish/paraphrase). Follows Conventional Commits with JIRA ticket detection.'
+metadata:
+  version: "1.1"
+  scope: [git, vcs]
+  trigger: "User requests creating a new commit, in any language or paraphrase"
+  auto_invoke: 'Invoke by INTENT not literal phrase. EN: "commit", "commit my changes", "create/make a commit", "save as commit", "ship this as a commit". ES: "haz commit", "crea un commit", "mete commit", "guarda en commit", "genera el commit". Skip for history reads ("show last commit", "what was in commit X").'
 allowed-tools:
-  - Bash(git:*)
   - Read
-model: sonnet
+  - Grep
+  - Glob
+  - Bash(git add:*)
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git branch:*)
+  - Bash(git log:*)
+  - Bash(git commit:*)
+  - Bash(git rev-parse:*)
+  - mcp__atlassian__jira_get_issue
+model: haiku
 ---
 
-# git:commit
+# Smart Commit
 
-Automate git commits following the Conventional Commits specification.
+## Dynamic Context (pre-resolved)
+
+- **Branch**: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "__NO_GIT__"`
+- **Status**: !`git status --short 2>/dev/null || echo "__NO_GIT__"`
+- **Diff stat**: !`git diff --stat 2>/dev/null || echo "__NO_GIT__"`
+- **Recent log**: !`git log --oneline -10 2>/dev/null || echo "__NO_GIT__"`
+
+> If any value above shows `__NO_GIT__`, the working directory is not a git repository. Ask the user which project to target, then run the git commands from that directory using `git -C <path>`.
+
+## Overview
+
+This skill automates the creation of git commits following the Conventional Commits specification with optional JIRA ticket integration. Analyze local changes, determine commit type and scope, detect breaking changes, and create properly formatted commits automatically.
 
 ## When to Invoke
 
-Invoke this skill when the user requests a commit, says "commit my changes", or asks you to "create a commit".
+Invoke this skill whenever the user asks you to create a commit, **in any language or paraphrase**. Match by intent, not by literal phrase:
 
-## Process
+- English: "commit", "commit my changes", "create a commit", "make a commit", "commit this", "save as commit", "let's commit", "ship it as a commit"
+- Spanish: "haz commit", "hazme un commit", "commit de esto", "mete commit", "crea un commit", "genera el commit", "guarda en commit", "vamos con el commit"
+- Indirect cues: the user pivots to "push this", "ship this", or "save progress" right after changes — confirm intent to commit, then invoke.
 
-1. Run `git status` to see all untracked and modified files.
-2. Run `git diff --staged` to see staged changes.
-3. Run `git log --oneline -5` to understand the commit style used in this repo.
-4. Analyze the changes and draft a commit message following Conventional Commits.
-5. Stage relevant files and create the commit.
+Do NOT invoke for history reads or amendments ("show me the last commit", "what was in commit X", "amend the previous commit"). The trigger is **creating a new commit** on top of working-tree changes.
 
-## Commit Message Format
+## Configuration
+
+This skill reads `config.json` from its own directory for project-specific settings:
+- `default_base_branch` — Base branch for comparisons (default: "main")
+- `jira_project_prefix` — Expected JIRA project prefix for branch detection (optional, e.g., "BUYERS")
+
+If `config.json` is not present or has empty values, the skill falls back to auto-detection from git context.
+
+## Commit Format
+
+All commits must follow this format:
 
 ```
-<type>(<scope>): <short description>
+[JIRA-ID] <type>(<scope>): <description>
 
-[optional body explaining WHY, not WHAT]
+[optional body]
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+[optional footer(s)]
 ```
 
-### Types
+**Breaking changes** use this format:
+```
+[JIRA-ID] <type>(<scope>)!: <description>
+```
 
-| Type | When to Use |
-|------|-------------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `refactor` | Code change that neither fixes a bug nor adds a feature |
-| `test` | Adding or updating tests |
-| `docs` | Documentation only changes |
-| `chore` | Maintenance tasks (deps, config) |
-| `ci` | CI/CD pipeline changes |
+## Workflow
 
-## Rules
+**Quick path**: If the branch name does not contain a JIRA-like pattern (`[A-Z]+-\d+`) AND no JIRA ID is found in recent commits, skip JIRA context enrichment (steps 1-2) and proceed directly to change analysis (step 3).
 
-- Keep the subject line under 72 characters.
-- Use imperative mood: "add feature" not "added feature".
-- Reference JIRA ticket in scope when available: `feat(PROJECT-123): add login`.
-- Never skip hooks (`--no-verify`) unless the user explicitly asks.
-- Never commit `.env` files or credentials.
+### Step 1: Extract JIRA ID from Branch Name
 
-Before finalizing your commit, check `gotchas.md` for common Claude mistakes when committing.
+Extract the JIRA ticket ID from the current git branch name.
+
+**Branch naming convention:**
+```
+<type>/<JIRA-ID>-<description>
+```
+
+**Examples:**
+- `feature/PROJ-123-user-authentication` → `PROJ-123`
+- `bugfix/PROJ-456-fix-validation` → `PROJ-456`
+- `refactor/APP-789-improve-performance` → `APP-789`
+
+**Commands:**
+```bash
+# Get current branch name
+git rev-parse --abbrev-ref HEAD
+
+# Extract JIRA ID using regex pattern: [A-Z]+-[0-9]+
+```
+
+**Extraction pattern:**
+- Find the first occurrence of uppercase letters followed by hyphen and numbers
+- Pattern: `[A-Z]+-[0-9]+`
+
+**Handle edge case:** If no JIRA ID is found in branch name, skip the JIRA ID prefix in the commit message and proceed without JIRA context.
+
+A helper script `scripts/branch-to-jira.sh` is available for reliable JIRA ID extraction from branch names. Usage: `bash scripts/branch-to-jira.sh [branch-name]` — returns the JIRA ID or empty string. If no argument is provided, it reads the current branch from git automatically.
+
+### Step 2: Fetch JIRA Ticket Information
+
+Once the JIRA ID is extracted, fetch the ticket details to enrich the commit message with context.
+
+**Use the JIRA MCP tool:**
+```
+mcp__atlassian__jira_get_issue
+```
+
+**Parameters:**
+- `issue_key`: The extracted JIRA ID (e.g., "PROJ-456")
+- `fields`: "summary,description,issuetype,labels"
+
+**Extract relevant information:**
+1. **Summary**: The ticket title/summary - use this to understand the high-level goal
+2. **Issue Type**: Bug, Story, Task, Epic, etc. - helps determine commit type
+3. **Description**: Detailed context about what needs to be done
+4. **Labels**: Additional context about the feature area
+
+**Mapping JIRA Issue Type to Commit Type:**
+| JIRA Issue Type | Suggested Commit Type | Notes |
+|-----------------|----------------------|-------|
+| Bug, Defect | `fix` | Bug fixes |
+| Story, User Story | `feat` | New features |
+| Task | `feat` or `refactor` | Depends on the nature of work |
+| Technical Debt | `refactor` | Code improvements |
+| Epic | `feat` | Large features (usually) |
+| Spike | `docs` or `refactor` | Research work |
+
+**How to use JIRA context:**
+- Use the **summary** as guidance for the commit description
+- Check **issue type** to help determine the correct commit type
+- Review **description** to understand if it's breaking, adds features, or fixes bugs
+- Consider **labels** for determining scope (e.g., "backend", "api", "domain")
+
+**Example:**
+```
+JIRA ID: PROJ-456
+Summary: "Migrate external service integration to v2"
+Issue Type: Task
+Description: "Update integration with external service to use new v2 API..."
+
+→ This suggests:
+  - Type: `feat` (new integration version)
+  - Scope: `infrastructure` (external service integration)
+  - Description should mention "migrate" and "v2"
+```
+
+**Handle errors gracefully:**
+- If JIRA API call fails (network, permissions, invalid ticket), log a warning and continue without JIRA context
+- Do NOT block the commit if JIRA is unavailable
+- The git diff analysis should still be the primary source of truth
+
+### Step 3: Analyze Local Changes
+
+Analyze the current git diff to understand what has changed.
+
+**Commands:**
+```bash
+# Get list of changed files with status
+git diff --name-status
+
+# Get detailed diff
+git diff
+
+# Get diff statistics
+git diff --stat
+```
+
+**Analyze the diff output to identify:**
+1. **Files changed**: Which files were modified, added, or deleted
+2. **Change magnitude**: How many lines added/removed
+3. **Change location**: Which modules/packages affected (domain, application, infrastructure, api-rest, etc.)
+4. **Change nature**: What kind of changes (new features, bug fixes, refactoring, etc.)
+
+**Combine with JIRA context:**
+- The git diff shows WHAT was actually changed in code
+- The JIRA ticket shows WHY and the intended outcome
+- Use BOTH sources to create an accurate commit message
+- If there's a mismatch (e.g., JIRA says "bug" but code shows new features), trust the git diff but consider mentioning the JIRA context
+
+### Step 4: Determine Commit Type
+
+Based on the analyzed changes, determine the commit type using these patterns:
+
+| Type | When to Use | Keywords in Changes |
+|------|------------|---------------------|
+| `feat` | New functionality or feature | "add", "implement", "introduce", "create" |
+| `fix` | Bug fix or error correction | "fix", "resolve", "correct", "repair", "patch" |
+| `refactor` | Code restructuring without behavior change | "refactor", "rename", "extract", "move", "simplify" |
+| `docs` | Documentation only changes | Changes only to .md files, docstrings, comments |
+| `test` | Test additions or modifications | Changes only to test files (*_test.go, *Test.java, *.test.ts, etc.) |
+| `style` | Code formatting, no logic change | "format", "style", "lint", whitespace only |
+| `perf` | Performance improvements | "cache", "optimize", "performance", "efficient" |
+| `build` | Build system or dependencies | Changes to build config (pom.xml, go.mod, package.json, Makefile, etc.) |
+| `ci` | CI/CD pipeline changes | Changes to .github/workflows, pipelines |
+| `chore` | Maintenance tasks | Configuration updates, cleanup |
+
+**Priority when multiple types apply:**
+1. Breaking changes (always mark with '!')
+2. `feat` (new functionality)
+3. `fix` (bug fixes)
+4. `perf` (performance)
+5. `refactor` (code improvements)
+6. Other types
+
+**Combine git diff analysis with JIRA issue type:**
+- Start with the JIRA issue type suggestion (from Step 2)
+- Validate against the actual code changes in git diff
+- Final decision: git diff takes priority, but JIRA provides context
+- Example: JIRA says "Task" but code adds new API endpoints → use `feat`
+
+**Reference:** For detailed detection patterns and examples, see [commit-patterns.md](references/commit-patterns.md) when needed.
+
+### Step 5: Determine Scope
+
+Extract the scope from the changed files to indicate which part of the codebase is affected.
+
+**Scope detection strategies:**
+
+#### Strategy 1: By Module (preferred for layered/hexagonal architectures)
+- Changes in `domain/` or `models/` → `domain`
+- Changes in `application/` or `services/` → `application`
+- Changes in `infrastructure/` or `adapters/` → `infrastructure`
+- Changes in `api/` or `controllers/` or `routes/` → `api`
+- Changes in `config/` or `bootstrap/` → `config`
+
+#### Strategy 2: By Domain Concept
+- Extract common prefix from changed files:
+  - `OrderService.java`, `OrderRepository.java` → `order`
+  - `UserEntity.java`, `UserMapper.java` → `user`
+  - `PaymentProcessor.java`, `PaymentValidator.java` → `payment`
+
+#### Strategy 3: By Feature Area
+- Authentication-related files → `auth`
+- Validation-related files → `validation`
+- Security-related files → `security`
+
+#### Strategy 4: Multiple Scopes
+- If changes affect multiple unrelated areas, either:
+  - Omit scope entirely
+  - Use the most significant scope
+  - Consider this indicates multiple commits might be needed
+
+**Examples:**
+```
+domain/entities/Order.java → scope: domain or order
+api-rest/controllers/UserController.java → scope: api or user
+infrastructure/repositories/ProductRepositoryImpl.java → scope: infrastructure or product
+```
+
+**Consider JIRA labels for scope:**
+- If JIRA ticket has labels like "backend", "api", "infrastructure", use them to validate scope
+- Labels can help when changes span multiple modules
+
+### Step 6: Detect Breaking Changes
+
+Identify if the changes include breaking changes that require the '!' marker.
+
+**Breaking change indicators:**
+1. Removed public API methods or endpoints
+2. Changed method signatures (parameters, return types)
+3. Changed API contracts (request/response models)
+4. Removed or renamed configuration properties
+5. Changed database schema (breaking migrations)
+6. Changed behavior that clients depend on
+
+**Keywords in diff:**
+- "remove", "delete" (of public APIs)
+- "rename" (for public interfaces)
+- "change signature"
+- "breaking"
+- "incompatible"
+
+**If breaking change detected:** Add '!' after type and scope:
+- `feat(api)!: remove deprecated endpoint`
+- `fix(domain)!: change order status validation`
+
+**Check JIRA description for breaking change mentions:**
+- JIRA ticket may explicitly mention "breaking change" or "incompatible"
+- Use this as additional signal, but verify with code changes
+
+### Step 7: Generate Commit Description
+
+Create a concise, imperative description of the change.
+
+**Description guidelines:**
+- Use imperative mood: "add feature" not "added feature" or "adds feature"
+- Start with lowercase letter (exception: proper nouns)
+- No period at the end
+- Be specific but concise (50 characters or less preferred)
+- Focus on WHAT changed, not HOW
+
+**Incorporate JIRA summary:**
+- Use the JIRA summary as inspiration for the description
+- Extract key terms from JIRA summary (e.g., "Migrate external service to v2" → "migrate external service integration to v2")
+- Combine with git diff insights to be more specific
+- Example:
+  - JIRA: "Update purchase variable integration"
+  - Git diff: Shows migration from v1 to v2 API
+  - Result: "migrate external service integration to v2"
+
+**Good examples:**
+- `add user authentication service`
+- `fix null pointer in order validation`
+- `refactor payment processing logic`
+- `improve query performance with caching`
+- `migrate external service integration to v2` (from JIRA + git context)
+
+**Bad examples:**
+- `Added new stuff` (too vague, wrong tense)
+- `Fixed a bug.` (too vague, has period)
+- `I have updated the code to use a better algorithm for processing orders` (too long, wrong perspective)
+
+### Step 8: Create the Commit
+
+Generate the final commit message and create the commit.
+
+**Commit message format:**
+```
+[JIRA-ID] <type>(<scope>): <description>
+```
+
+**Examples:**
+```
+[PROJ-123] feat(domain): add order creation validation
+[PROJ-456] fix(api): handle null pointer in user lookup
+[APP-789] refactor(infrastructure): simplify repository implementation
+[TASK-321] perf(application)!: change caching strategy for performance
+```
+
+**Commands to create commit:**
+```bash
+# Review staged and unstaged files first
+git status
+
+# Stage only reviewed files — avoid git add . to prevent committing sensitive files (.env, credentials)
+git add <file1> <file2> …
+
+# Create commit with generated message
+git commit -m "[JIRA-ID] type(scope): description"
+
+# Verify commit was created
+git log -1 --oneline
+```
+
+**Important:**
+- **Do NOT include** "Co-Authored-By: Claude <noreply@anthropic.com>" or any references to AI in the commit message
+- Do NOT ask for user confirmation, create the commit automatically
+- Stage only reviewed files; use `git add .` only if all unstaged files have been verified via `git status`
+- Use the exact message format generated
+
+**Commit body (optional but recommended for complex changes):**
+If the change is complex or involves multiple aspects, use the commit body to provide more context:
+```
+[JIRA-ID] type(scope): description
+
+- Detail 1 from git diff
+- Detail 2 from git diff
+- Detail 3 from git diff
+```
+
+Example incorporating JIRA context:
+```
+[PROJ-456] feat(infrastructure): migrate external service integration to v2
+
+- Update rest client to use service-rest v2.0.0
+- Refactor domain model and mapper for new API contract
+- Update repository implementation for v2 endpoints
+- Remove deprecated fields from domain model
+- Add new configuration properties for v2 endpoints
+```
+
+### Step 9: Verify and Report
+
+After creating the commit, verify it was successful and report to the user.
+
+**Verification commands:**
+```bash
+# Show the created commit
+git log -1 --format="%h %s"
+
+# Show commit details
+git show --stat HEAD
+```
+
+**Report to user:**
+- Confirm commit was created
+- Show the commit hash and message
+- Show brief statistics of what was committed
+
+## Gotchas
+
+- **JIRA ID regex**: Do not use `[A-Z]+[A-Z]+-[0-9]+` for JIRA ID extraction — it fails on single-letter project keys (e.g., `A-123`). Always use `[A-Z]+-\d+`.
+- **Staging**: Do not run `git add .` without first reviewing `git status` — unverified files (`.env`, credentials, binaries) may be staged accidentally.
+- **Empty diff**: Do not create a commit when `git diff` is empty — report "nothing to commit" instead of proceeding.
+- **AI attribution**: Do not include "Co-Authored-By: Claude" or any AI co-authorship lines in the commit message.
+- **Commit type priority**: Do not override the priority order when multiple types apply — breaking changes (`!`) always take precedence, then `feat`, then `fix`.
+- **JIRA unavailability**: If the JIRA MCP call fails, continue with git diff analysis only — do not block the commit.
+
+Before finalizing your commit, also review [gotchas.md](gotchas.md) for broader anti-patterns Claude commonly makes when committing.
+
+## Complete Example Workflow
+
+A full end-to-end walkthrough covering branch parsing, JIRA lookup, diff analysis, and commit creation. For the detailed step-by-step execution, see [commit-examples.md](references/commit-examples.md).
+
+## Advanced Scenarios
+
+Covers multiple unrelated changes, breaking changes, missing JIRA IDs, and how JIRA context improves commit messages. For detailed scenarios and examples, see [commit-examples.md](references/commit-examples.md#advanced-scenarios).
+
+## References
+
+- [commit-patterns.md](references/commit-patterns.md) - Comprehensive patterns for commit type detection, scope determination, and breaking change identification with real examples
+- [commit-examples.md](references/commit-examples.md) - Full end-to-end workflow example and advanced scenario walkthroughs
+- [gotchas.md](gotchas.md) - Common Claude anti-patterns when committing
+- [git-pull-request](../git-pull-request/SKILL.md) - Create a pull request after committing (`git-pull-request`)
+
+## Best Practices
+
+1. **Be specific but concise** - Describe what changed, not how it was implemented
+2. **Use project conventions** - Follow the project's module and directory naming for scopes
+3. **One logical change per commit** - If changes are unrelated, suggest separate commits
+4. **Focus on user impact** - Describe changes from user/developer perspective
+5. **Detect breaking changes carefully** - Only mark as breaking if it truly affects consumers
+6. **Keep scope consistent** - Use the same scope naming throughout the project
+
+## Anti-patterns to Avoid
+
+- 🚫 Do not use the regex `[A-Z]+[A-Z]+-[0-9]+` for JIRA ID extraction; use `[A-Z]+-[0-9]+`
+- 🚫 Do not stage files with `git add .` without first running `git status` to review
+- 🚫 Do not include AI co-authorship lines in the commit message
+- 🚫 Do not commit when `git diff` is empty — report "nothing to commit" instead
+- 🚫 Do not override the commit-type priority order when multiple types apply
+
+## Notes
+
+- This skill operates in "local mode" using git commands directly
+- No user confirmation is required - analyze and commit automatically
+- All changes are staged with `git add .` before committing
+- JIRA ID in branch names is optional; if not found, the `[JIRA-ID]` prefix is omitted from the commit message
+- For multi-module projects, prefer module-based scopes (domain, application, infrastructure)
+- **JIRA integration is optional**: If JIRA API is unavailable or fails, the skill continues with git diff analysis only
+- **Git diff is the source of truth**: JIRA provides context and suggestions, but actual code changes determine the final commit type and scope
+- The JIRA MCP tool (`mcp__atlassian__jira_get_issue`) requires proper authentication and network access to Jira instance

--- a/skills/git-commit/config.json
+++ b/skills/git-commit/config.json
@@ -1,0 +1,4 @@
+{
+  "default_base_branch": "develop",
+  "jira_project_prefix": ""
+}

--- a/skills/git-commit/references/commit-examples.md
+++ b/skills/git-commit/references/commit-examples.md
@@ -1,0 +1,142 @@
+# Commit Examples
+
+End-to-end workflow examples and advanced scenarios for the `git:commit` skill.
+
+## Complete Example Workflow
+
+**Scenario:** User says "commit my changes"
+
+**Step-by-step execution:**
+
+1. **Extract JIRA ID:**
+   ```bash
+   $ git rev-parse --abbrev-ref HEAD
+   feature/PROJ-456-add-order-validation
+   ```
+   JIRA ID: `PROJ-456`
+
+2. **Fetch JIRA ticket information:**
+   ```
+   mcp__atlassian__jira_get_issue(
+     issue_key: "PROJ-456",
+     fields: "summary,description,issuetype,labels"
+   )
+   ```
+   Response:
+   ```json
+   {
+     "key": "PROJ-456",
+     "fields": {
+       "summary": "Add custom validation rules for purchase orders",
+       "issuetype": {"name": "Story"},
+       "labels": ["backend", "validation"],
+       "description": "Implement validation logic for order creation..."
+     }
+   }
+   ```
+
+3. **Analyze git changes:**
+   ```bash
+   $ git diff --name-status
+   A    domain/entities/OrderValidation.java
+   M    domain/services/OrderService.java
+   A    domain/valueobjects/ValidationResult.java
+   M    application/usecases/CreateOrderUseCase.java
+   ```
+
+4. **Determine type:**
+   - JIRA suggests: `feat` (Story type)
+   - Git diff confirms: `feat` (new files added with business logic)
+   - Final: `feat`
+
+5. **Determine scope:**
+   - Git diff shows: mostly `domain/` changes
+   - JIRA labels: "backend", "validation"
+   - Final: `domain` (primary location)
+
+6. **Check breaking changes:** None detected
+
+7. **Generate description:**
+   - JIRA summary: "Add custom validation rules for purchase orders"
+   - Git changes: new validation entities and use case updates
+   - Final: `add order validation with custom rules`
+
+8. **Create commit:**
+   ```bash
+   $ git add .
+   $ git commit -m "[PROJ-456] feat(domain): add order validation with custom rules"
+   ```
+
+9. **Verify and report:**
+   ```bash
+   $ git log -1 --format="%h %s"
+   a3f5d21 [PROJ-456] feat(domain): add order validation with custom rules
+   ```
+
+   Report: "Created commit a3f5d21: [PROJ-456] feat(domain): add order validation with custom rules"
+
+## Advanced Scenarios
+
+### Scenario: Multiple Unrelated Changes
+
+If the diff shows multiple unrelated changes (e.g., domain changes + documentation + CI fixes), consider the dominant change type or suggest the user commit separately.
+
+**Approach:**
+1. Identify the most significant change
+2. Use that for the commit type
+3. Optionally mention other changes in commit body
+
+**Example:**
+```
+[PROJ-123] feat(domain): add user preferences
+
+- Add domain entity and value objects
+- Update API documentation
+- Fix CI pipeline warning
+```
+
+### Scenario: Breaking Change
+
+When a breaking change is detected:
+
+```
+[PROJ-123] feat(api)!: remove deprecated authentication endpoint
+
+BREAKING CHANGE: The /auth/legacy endpoint has been removed.
+Use /auth/v2 instead.
+```
+
+### Scenario: No JIRA ID in Branch
+
+If branch name doesn't contain JIRA ID (e.g., `main`, `develop`, or malformed branch name):
+
+**Option 1:** Omit JIRA ID prefix
+```
+feat(domain): add order validation
+```
+
+**Option 2:** Ask user for JIRA ID (if context suggests it's needed)
+
+### Scenario: JIRA Context Improves Commit Message
+
+**Without JIRA integration:**
+```
+Branch: dependency/PROJ-4991-migracion-bc-
+Git diff: Shows changes in infrastructure/, pom.xml updates, config changes
+Result: [PROJ-4991] refactor(infrastructure): update dependencies
+```
+
+**With JIRA integration:**
+```
+Branch: dependency/PROJ-4991-migracion-bc-
+JIRA Summary: "Migrate BC Assortment Planning integration to v2"
+JIRA Type: Task
+Git diff: Shows bc-assortment-planning-rest v1->v2, API contract changes
+Result: [PROJ-4991] feat(infrastructure): migrate BC Assortment Planning integration to v2
+```
+
+The JIRA context reveals:
+- The change is a migration (more specific than "update")
+- It's specifically about BC Assortment Planning (extracted from JIRA)
+- It's version 2 (from JIRA summary)
+- It should be `feat` not `refactor` (new version = new functionality)

--- a/skills/git-commit/references/commit-patterns.md
+++ b/skills/git-commit/references/commit-patterns.md
@@ -1,0 +1,248 @@
+# Commit Type Detection Patterns
+
+This reference provides detailed patterns for detecting commit types and scopes from git changes.
+
+## Commit Type Mapping
+
+### feat (Feature)
+**Indicators:**
+- New files added with business logic (entities, services, controllers, use cases)
+- New API endpoints or methods
+- New functionality in existing classes
+- New configuration for features
+- Keywords in changes: "add", "implement", "introduce", "create"
+
+**Examples:**
+- Adding new REST endpoint
+- Creating new domain entity or value object
+- Implementing new use case
+- Adding new service method
+
+### fix (Bug Fix)
+**Indicators:**
+- Changes to conditional logic or validation
+- Error handling improvements
+- Null checks or defensive programming
+- Test fixes that correct behavior
+- Keywords in changes: "fix", "resolve", "correct", "repair", "patch"
+
+**Examples:**
+- Fixing null pointer exceptions
+- Correcting validation logic
+- Resolving race conditions
+- Fixing incorrect calculations
+
+### refactor (Code Refactoring)
+**Indicators:**
+- Renaming classes, methods, or variables
+- Extracting methods or classes
+- Moving code between files
+- Changing code structure without behavior change
+- Simplifying logic
+- Keywords in changes: "refactor", "rename", "extract", "move", "simplify", "reorganize"
+
+**Examples:**
+- Extracting common logic into utility methods
+- Renaming for clarity
+- Restructuring packages
+- Simplifying complex conditions
+
+### docs (Documentation)
+**Indicators:**
+- Only changes to .md files
+- Only changes to Javadoc comments
+- Only changes to README, CHANGELOG, or documentation files
+- Keywords in changes: "document", "comment", "readme", "changelog"
+
+**Examples:**
+- Updating README
+- Adding Javadoc to methods
+- Updating API documentation
+- Adding architecture diagrams
+
+### test (Testing)
+**Indicators:**
+- Only changes to test files (*Test.java, *IT.java)
+- Adding or modifying test cases
+- Test data or mock changes
+- Keywords in changes: "test", "mock", "assert", "verify"
+
+**Examples:**
+- Adding unit tests
+- Adding integration tests
+- Updating test data
+- Fixing flaky tests
+
+### style (Code Style)
+**Indicators:**
+- Formatting changes only
+- Import organization
+- Code style compliance (linting)
+- Whitespace changes
+- Keywords in changes: "format", "style", "lint", "whitespace"
+
+**Examples:**
+- Running code formatter
+- Organizing imports
+- Fixing linting errors
+- Removing trailing whitespace
+
+### perf (Performance)
+**Indicators:**
+- Caching implementations
+- Query optimization
+- Algorithm improvements
+- Lazy loading
+- Batch processing
+- Keywords in changes: "cache", "optimize", "performance", "speed", "efficient"
+
+**Examples:**
+- Adding caching layer
+- Optimizing database queries
+- Improving algorithm complexity
+- Adding indexes
+
+### build (Build System)
+**Indicators:**
+- Changes to pom.xml
+- Changes to build configuration
+- Dependency updates
+- Maven plugin configuration
+- Keywords in changes: "dependency", "maven", "build", "plugin"
+
+**Examples:**
+- Updating dependencies
+- Adding new Maven plugin
+- Changing Java version
+- Updating build configuration
+
+### ci (CI/CD)
+**Indicators:**
+- Changes to .github/workflows
+- Changes to pipeline configuration
+- Changes to deployment scripts
+- Keywords in changes: "pipeline", "workflow", "deploy", "ci", "cd"
+
+**Examples:**
+- Updating GitHub Actions
+- Modifying deployment pipeline
+- Adding CI checks
+
+### chore (Maintenance)
+**Indicators:**
+- Configuration file changes (not build)
+- Routine maintenance
+- Miscellaneous changes that don't fit other categories
+- Keywords in changes: "chore", "maintenance", "update", "cleanup"
+
+**Examples:**
+- Updating application.yml
+- Cleaning up unused code
+- Updating gitignore
+- General maintenance
+
+## Scope Detection Patterns
+
+The scope should reflect the affected module or component. Extract scope from:
+
+### By Module
+- Changes in `domain/` → scope: `domain`
+- Changes in `application/` → scope: `application`
+- Changes in `infrastructure/` → scope: `infrastructure`
+- Changes in `api-rest/` → scope: `api` or `rest`
+- Changes in `boot/` → scope: `boot`
+
+### By Domain Concept
+- Changes to files with common prefix → scope: prefix
+  - `OrderService.java`, `OrderRepository.java` → scope: `order`
+  - `UserEntity.java`, `UserMapper.java` → scope: `user`
+
+### By Feature Area
+- Multiple related files → scope: feature name
+  - Authentication files → scope: `auth`
+  - Validation files → scope: `validation`
+
+### Multiple Scopes
+- If changes span multiple unrelated areas, consider omitting scope or using the most significant one
+
+## Breaking Change Detection
+
+A change is breaking if it:
+
+1. **Removes public API methods or endpoints**
+2. **Changes method signatures** (parameters, return types)
+3. **Changes API contract** (request/response models)
+4. **Removes or renames configuration properties**
+5. **Changes database schema** (breaking migrations)
+6. **Changes behavior** that clients depend on
+
+**Keywords indicating breaking changes:**
+- "remove", "delete", "breaking"
+- "rename" (for public APIs)
+- "change signature"
+- "incompatible"
+- "migration required"
+
+**Format:** Add `!` after type/scope: `feat(api)!:` or `fix!:`
+
+## Priority Rules for Multiple Change Types
+
+When changes include multiple types, prioritize in this order:
+
+1. **Breaking changes** → Always mention first with `!`
+2. **feat** → New functionality takes precedence
+3. **fix** → Bug fixes are important
+4. **perf** → Performance improvements
+5. **refactor** → Code improvements
+6. **test** → Test additions
+7. **docs** → Documentation updates
+8. **style** → Style changes
+9. **build/ci/chore** → Maintenance
+
+If changes are truly mixed and equal, consider splitting into multiple commits.
+
+## Examples
+
+### Example 1: Adding New Feature
+```diff
++ public class OrderService {
++   public Order createOrder(OrderRequest request) {
++     // new business logic
++   }
++ }
+```
+**Type:** `feat`, **Scope:** `order`, **Message:** `feat(order): add order creation service`
+
+### Example 2: Fixing Bug
+```diff
+- if (user == null) {
+-   return null;
+- }
++ if (user == null) {
++   throw new UserNotFoundException();
++ }
+```
+**Type:** `fix`, **Scope:** `user`, **Message:** `fix(user): handle null user with proper exception`
+
+### Example 3: Breaking Change
+```diff
+- public String getOrderId()
++ public OrderId getOrderId()
+```
+**Type:** `feat`, **Breaking:** yes, **Scope:** `order`, **Message:** `feat(order)!: change order ID to value object`
+
+### Example 4: Refactoring
+```diff
+- private void validateOrder(Order order) { /* 50 lines */ }
++ private void validateOrder(Order order) {
++   orderValidator.validate(order);
++ }
+```
+**Type:** `refactor`, **Scope:** `order`, **Message:** `refactor(order): extract validation logic to dedicated validator`
+
+### Example 5: Performance Improvement
+```diff
++ @Cacheable("users")
+  public User findUserById(String id) {
+```
+**Type:** `perf`, **Scope:** `user`, **Message:** `perf(user): add caching to user lookup`

--- a/skills/git-commit/scripts/branch-to-jira.sh
+++ b/skills/git-commit/scripts/branch-to-jira.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Extract JIRA ticket ID from a git branch name
+# Usage: branch-to-jira.sh [branch-name]
+# If no argument provided, reads current branch from git
+# Returns: JIRA ID (e.g., "PROJ-123") or empty string if none found
+#
+# Examples:
+#   branch-to-jira.sh "feature/BUYERS-456-add-login"  → BUYERS-456
+#   branch-to-jira.sh "hotfix/FIX-12-urgent"          → FIX-12
+#   branch-to-jira.sh "main"                          → (empty)
+
+branch="${1:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}"
+
+if [ -z "$branch" ]; then
+  exit 0
+fi
+
+echo "$branch" | grep -oE '[A-Z]+-[0-9]+' | head -1

--- a/skills/git-pull-request/SKILL.md
+++ b/skills/git-pull-request/SKILL.md
@@ -1,63 +1,423 @@
 ---
 name: git-pull-request
-description: "Create pull requests with template selection and platform auto-detection (GitHub/GitLab)."
+description: 'Use when the user asks to create/open a PR or MR in ANY language or paraphrase (English/Spanish). Auto-detects GitHub/GitLab, selects PR template, and enriches with JIRA context.'
+metadata:
+  version: "2.1"
+  scope: [git, vcs]
+  trigger: "User requests creating/opening a new PR or MR, in any language or paraphrase"
+  auto_invoke: 'Invoke by INTENT not literal phrase. EN: "create/open PR", "open MR", "merge request", "submit PR", "push up a PR", "send for review", "raise a PR". ES: "abre el PR", "crea el PR", "si crea el pr", "mete un PR", "sube el PR", "lanza el PR", "haz el PR", "abre la MR". Skip for reviewing/listing/commenting on existing PRs — that belongs to review-pr.'
 allowed-tools:
+  - Read
+  - Grep
+  - Glob
   - Bash(git:*)
   - Bash(gh:*)
-  - Read
-model: sonnet
+  - Bash(glab:*)
+  - mcp__atlassian__jira_get_issue
+model: haiku
 ---
 
-# git:pull-request
+# PR Creator
 
-Create pull requests with auto-detection for GitHub and GitLab platforms.
+## Dynamic Context (pre-resolved)
+
+- **Remote URL**: !`git remote get-url origin 2>/dev/null || echo "__NO_GIT__"`
+- **Branch**: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "__NO_GIT__"`
+- **Base branch**: !`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "main"`
+- **Status**: !`git status --short 2>/dev/null || echo "__NO_GIT__"`
+- **Diff vs base**: !`git diff --stat origin/HEAD...HEAD 2>/dev/null || echo "__NO_GIT__"`
+- **Commits vs base**: !`git log --oneline origin/HEAD..HEAD 2>/dev/null || echo "__NO_GIT__"`
+
+> If any value above shows `__NO_GIT__`, the working directory is not a git repository. Ask the user which project to target, then run the git commands from that directory using `git -C <path>`.
+
+## Overview
+
+This skill enables intelligent pull request creation by analyzing local git changes, fetching JIRA ticket context, suggesting the most appropriate PR template based on change type, and helping fill out comprehensive PR descriptions that accurately reflect the code modifications and business requirements. It supports both GitHub (via `gh`) and GitLab (via `glab`) with automatic platform detection.
 
 ## When to Invoke
 
-Invoke this skill when the user requests "create PR", "create pull request", or "open a pull request".
+Invoke this skill whenever the user asks you to create or open a PR/MR, **in any language or paraphrase**. Match by intent, not by literal phrase:
 
-## Process
+- English: "create PR", "create pull request", "open a pull request", "open PR", "open MR", "open a merge request", "submit PR", "push up a PR", "send it for review", "raise a PR"
+- Spanish: "abre el PR", "crea el PR", "crea un pull request", "si crea el pr", "mete un PR", "abre una MR", "sube el PR", "lanza el PR", "haz el PR", "abre la merge request"
+- Indirect cues: after a feature branch is pushed, the user says "ship this for review" or "send it upstream" — treat as an open-PR request.
 
-1. Run `git status` and `git log` to understand the current branch and commits.
-2. Run `git diff <base-branch>...HEAD` to see all changes since diverging from base.
-3. Determine the platform (GitHub via `gh`, GitLab via `glab`).
-4. Analyze all commits to draft a PR title and summary.
-5. Create the PR using the platform CLI.
+Do NOT invoke when the user is asking to **review, list, comment on, or merge** an existing PR — those belong to `review-pr` or direct `gh pr` commands. The trigger here is exclusively **creating a new PR or MR** from the current branch.
 
-## PR Title Guidelines
+## Configuration
 
-- Keep under 70 characters.
-- Use imperative mood: "Add login flow" not "Added login flow".
-- Reference JIRA/issue number when available.
+This skill reads `config.json` from its own directory for project-specific settings:
+- `default_base_branch` — Base branch for PR target (default: "main")
+- `jira_project_prefix` — Expected JIRA project prefix for branch detection (optional, e.g., "BUYERS")
+- `pr_platform` — Force platform override: "github" or "gitlab" (optional, auto-detected if empty)
 
-## PR Body Template
+If `config.json` is not present or has empty values, the skill falls back to auto-detection from git remote URL.
 
-```markdown
-## Summary
-- <bullet point summary of what changed>
-- <and why>
+## Workflow
 
-## Test Plan
-- [ ] Unit tests pass
-- [ ] Integration tests pass
-- [ ] Manual testing done
+### Step 1: Understand Parameters
 
-🤖 Generated with Claude Code
+Extract parameters from the context or ask the user:
+- `base_branch`: Branch to compare against (default: `develop` or `main` depending on project)
+- `head_branch`: Branch with changes (default: current branch from `git rev-parse --abbrev-ref HEAD`)
+- `working_directory`: Git repository path (default: current working directory)
+
+### Step 2: Detect Git Platform
+
+Determine whether the repository is hosted on GitHub or GitLab by inspecting the git remote URL.
+
+**Commands:**
+```bash
+# Get the remote URL
+git remote get-url origin
 ```
 
-## Platform Detection
+**Platform detection patterns:**
+| Remote URL Pattern | Platform | CLI Tool |
+|-------------------|----------|----------|
+| Contains `github.com` or `github.` | GitHub | `gh` |
+| Contains `gitlab.com` or `gitlab.` | GitLab | `glab` |
 
-| CLI Available | Platform |
-|---------------|----------|
-| `gh` | GitHub |
-| `glab` | GitLab |
-| Neither | Manual instructions |
+**Examples:**
+- `git@github.com:org/repo.git` --> GitHub --> use `gh`
+- `https://github.com/org/repo.git` --> GitHub --> use `gh`
+- `git@gitlab.com:org/repo.git` --> GitLab --> use `glab`
+- `https://gitlab.company.com/org/repo.git` --> GitLab --> use `glab`
 
-## Rules
+**Fallback:** If the remote URL does not match either pattern, ask the user which platform they are using.
 
-- Never push to `main` or `master` directly.
-- Always push the current branch first (`git push -u origin HEAD`).
-- Never use `--force` unless the user explicitly requests it.
-- Return the PR URL when done.
+### Step 3: Extract JIRA ID from Branch Name
 
-Before finalizing your PR, check `gotchas.md` for common Claude mistakes when creating pull requests.
+Extract the JIRA ticket ID from the current git branch name to fetch ticket context.
+
+**Branch naming convention:**
+```
+<type>/<JIRA-ID>-<description>
+```
+
+**Examples:**
+- `feature/PROJ-123-user-authentication` → `PROJ-123`
+- `bugfix/PROJ-456-fix-validation` → `PROJ-456`
+- `refactor/APP-789-improve-performance` → `APP-789`
+
+**Commands:**
+```bash
+# Get current branch name
+git rev-parse --abbrev-ref HEAD
+
+# Extract JIRA ID using regex pattern: [A-Z]+-[0-9]+
+```
+
+**Handle edge case:** If no JIRA ID is found in branch name, skip JIRA enrichment and proceed with git diff analysis only.
+
+### Step 4: Fetch JIRA Ticket Information
+
+Once the JIRA ID is extracted, fetch the ticket details to enrich the PR description.
+
+**Use the JIRA MCP tool:**
+```
+mcp__atlassian__jira_get_issue
+```
+
+**Parameters:**
+- `issue_key`: The extracted JIRA ID (e.g., "PROJ-456")
+- `fields`: "summary,description,issuetype,labels,assignee,status,priority,fixVersions,components"
+
+**Extract relevant information:**
+1. **Summary**: The ticket title - use for PR title
+2. **Issue Type**: Bug, Story, Task, Epic - helps determine PR template
+3. **Description**: Detailed context - use for "Motivation" or "Background" sections
+4. **Labels**: Additional context for categorization
+5. **Components**: Affected system components
+6. **Acceptance Criteria**: Often in description - use for testing section
+
+**Mapping JIRA Issue Type to PR Template:**
+| JIRA Issue Type | PR Template | Rationale |
+|-----------------|-------------|-----------|
+| Bug, Defect | `bug.md` | Fixing issues |
+| Story, User Story | `feature.md` | New functionality |
+| Task | Based on git diff | Could be feature, refactor, or maintenance |
+| Technical Debt | `refactor.md` | Code improvements |
+| Epic | `feature.md` | Large features |
+| Spike | `docs.md` or `refactor.md` | Research work |
+
+**How to use JIRA context in PR:**
+- **PR Title**: Use JIRA summary prefixed with ticket ID: `[JIRA-123] Summary from ticket`
+- **Motivation/Background**: Extract from JIRA description
+- **Acceptance Criteria**: Parse from JIRA description (often marked with headers)
+- **Related Issues**: Link to JIRA ticket and any related tickets mentioned
+- **Business Context**: Use JIRA description to explain "why" this change matters
+
+**Example:**
+```
+JIRA ID: PROJ-456
+Summary: "Migrate external service integration to v2"
+Issue Type: Task
+Description: "Migrate all v1 endpoints to v2 API..."
+Components: ["Infrastructure", "Integration"]
+
+→ This suggests:
+  - PR Title: "[PROJ-456] Migrate external service integration to v2"
+  - Template: feature.md (migration to new version)
+  - Motivation: From JIRA description
+  - Testing: Focus on endpoint compatibility
+```
+
+**Handle errors gracefully:**
+- If JIRA API call fails, log a warning and continue without JIRA context
+- Do NOT block PR creation if JIRA is unavailable
+- Git diff analysis remains the primary source for technical details
+
+### Step 5: Analyze File Changes
+
+Use git commands to gather comprehensive change information:
+
+```bash
+# Get current branch
+git rev-parse --abbrev-ref HEAD
+
+# Get repository root
+git rev-parse --show-toplevel
+
+# Get changed files with status
+git diff --name-status <base_branch>...<head_branch>
+
+# Get diff statistics
+git diff --stat <base_branch>...<head_branch>
+
+# Get commit messages
+git log --oneline <base_branch>..<head_branch>
+
+# Get full diff
+git diff <base_branch>...<head_branch>
+```
+
+Analyze the output to understand:
+1. **Change scope**: Number of files changed, lines added/removed
+2. **Change type**: Bug fix, feature, refactor, docs, test, performance, security
+3. **Change impact**: Which modules/components are affected
+4. **Breaking changes**: API changes, removed functionality
+
+**Combine with JIRA context:**
+- Git diff shows WHAT was changed technically
+- JIRA ticket shows WHY and the business requirements
+- Use BOTH to create a comprehensive PR description
+- JIRA description may reveal context not obvious from code (e.g., regulatory requirements, customer requests)
+
+### Step 6: Determine Change Type
+
+Based on the diff analysis, classify the change into one of these types:
+
+- **bug/fix**: Fixes defects, errors, or unexpected behavior
+- **feature/enhancement**: Adds new functionality or capabilities
+- **docs/documentation**: Documentation-only changes
+- **refactor/cleanup**: Code restructuring without behavior changes
+- **test/testing**: Test additions or corrections
+- **performance/optimization**: Performance improvements
+- **security**: Security fixes or hardening
+
+**Type detection patterns:**
+- Bug fixes: Keywords like "fix", "bug", "error", "issue" in commits/changes
+- Features: New files, classes, or public APIs; keywords like "add", "implement"
+- Refactor: Moved code, renamed classes/methods, structural changes
+- Docs: Only markdown/documentation files changed
+- Tests: Changes primarily in test directories
+- Performance: Optimization-related changes, caching, query improvements
+- Security: Authentication, authorization, encryption, vulnerability fixes
+
+**Combine git diff analysis with JIRA issue type:**
+- Start with JIRA issue type suggestion (from Step 3)
+- Validate against actual code changes in git diff
+- Final decision: Consider both sources
+- Example: JIRA says "Task" + git shows v1→v2 API migration → use `feature` template
+
+### Step 7: Select Template
+
+**Quick path**: If `git diff --stat` shows changes to a single file only, skip template selection and use the default template (`feature.md`). For changes affecting 2+ files, proceed with full template selection below.
+
+Map the change type to the appropriate template from `assets/templates/`:
+
+| Change Type | Template File | Description |
+|-------------|--------------|-------------|
+| bug, fix | `bug.md` | Bug fix template with issue description and fix details |
+| feature, enhancement | `feature.md` | New feature template with motivation and implementation |
+| docs, documentation | `docs.md` | Documentation change template |
+| refactor, cleanup | `refactor.md` | Refactoring template with before/after context |
+| test, testing | `test.md` | Test addition template with coverage details |
+| performance, optimization | `performance.md` | Performance improvement template with metrics |
+| security | `security.md` | Security fix template with vulnerability details |
+
+Read the selected template from `assets/templates/<template-file>`.
+
+### Step 8: Fill Out Template with JIRA Context
+
+Based on the analyzed changes AND JIRA ticket information, populate each section of the selected template. Each template has specific sections to fill (issue description, motivation, implementation, testing, related issues, etc.).
+
+**Key principles:**
+- Use JIRA description for business context (motivation, acceptance criteria)
+- Use git diff for technical details (implementation, files changed)
+- Always include a JIRA reference in "Related Issues": use the JIRA ticket ID (e.g., `JIRA-ID`). If the JIRA server URL is known (e.g., from MCP Atlassian configuration), construct a full link; otherwise, reference the ticket ID in plain text.
+- If JIRA has acceptance criteria, include them as checkboxes
+
+For detailed per-template fill-out guidance and a full example, see [references/pr-templates-guide.md](references/pr-templates-guide.md).
+
+### Step 9: Create Pull Request
+
+Use the platform-specific command based on the platform detected in Step 2.
+
+**GitHub (using `gh`):**
+
+```bash
+gh pr create \
+  --base <base_branch> \
+  --draft \
+  --title "<title>" \
+  --body "<filled-template>"
+```
+
+**GitLab (using `glab`):**
+
+```bash
+glab mr create \
+  --source-branch <head_branch> \
+  --target-branch <base_branch> \
+  --draft \
+  --title "<title>" \
+  --description "<filled-template>"
+```
+
+**Validation checklist before running command:**
+- [ ] `--draft` flag is present
+- [ ] Title starts with `[JIRA-ID]` (if JIRA ID was found)
+- [ ] Body includes JIRA reference in "Related Issues" section
+
+**Important guidelines:**
+- **Title format**: `[JIRA-ID] <Summary from JIRA or descriptive title>`
+  - Example: `[PROJ-123] Migrate service integration to v2`
+  - Use JIRA summary as the base, refined if needed for clarity
+- Do NOT include Claude Code co-authorship
+- Ensure body includes reference to JIRA ticket in "Related Issues" section
+- If JIRA has acceptance criteria, include them as checkboxes in PR description
+- Add labels as needed for your team's workflow (e.g., `--label "ready-for-review"` on GitHub)
+
+### Step 10: Handle Special Cases
+
+**Multiple change types:**
+- If changes span multiple types, choose the dominant type
+- List other changes as "Additional changes" in PR description
+
+**Breaking changes:**
+- Add `BREAKING CHANGE:` section to description
+- Clearly document what breaks and migration path
+
+**Follow-up items:**
+- If issues are discovered that need separate PRs, list them as action items
+- Use checkboxes for clarity: `- [ ] Follow-up: Add unit tests for edge cases`
+
+## Gotchas
+
+- **JIRA ID prefix in title**: Do not omit the JIRA ID prefix from the PR title when one is available — it breaks traceability in CI/CD pipelines and JIRA automation.
+- **Template selection**: Do not select a template based solely on JIRA issue type — always validate against the actual git diff, which is the source of truth.
+- **JIRA unavailability**: Do not block PR creation if the JIRA API fails — fall back to git diff analysis and commit messages.
+- **AI attribution**: Do not include Claude co-authorship lines in the PR body.
+- **Draft flag**: Always create PRs in draft mode (`--draft`) — let the author promote to ready.
+
+Before finalizing your PR, also review [gotchas.md](gotchas.md) for broader anti-patterns Claude commonly makes when opening PRs (wrong base branch, force-pushing protected branches, stale-branch PRs, missing upstream, duplicating the diff in prose, skipping CI check).
+
+## Template Assets
+
+Seven templates are available in `assets/templates/`: `bug.md`, `feature.md`, `docs.md`, `refactor.md`, `test.md`, `performance.md`, and `security.md`. For descriptions and fill-out guidance, see [references/pr-templates-guide.md](references/pr-templates-guide.md).
+
+## Conventions
+
+**PR Title:**
+- Prefix PR titles with JIRA ticket ID when available: `[PROJ-123] Description`
+- Use JIRA summary as the base for the title
+- Follow Conventional Commits in individual commits: `type(scope): description`
+
+**JIRA Integration:**
+- Extract acceptance criteria from JIRA description (look for sections marked with "Acceptance Criteria", "AC:", "*Acceptance Criteria*")
+- Include JIRA business context in "Motivation" section
+- Reference any related JIRA tickets mentioned in the description
+
+**Branch Workflow:**
+- Create feature branches from main/develop
+- Use descriptive branch names: `feature/add-user-auth`, `fix/login-timeout`
+- Keep PRs focused and reasonably sized
+- Reference related issues in PR description
+
+## Error Handling
+
+**If git commands fail:**
+- Verify working directory is a git repository
+- Check that base and head branches exist
+- Ensure user has proper git configuration
+
+**If the platform CLI is not available:**
+- GitHub: Provide instructions to install `gh`: `brew install gh` (macOS) or download from GitHub
+- GitLab: Provide instructions to install `glab`: `brew install glab` (macOS) or download from GitLab
+- Suggest manual PR/MR creation with the filled template
+
+**If analysis is ambiguous:**
+- Ask user to clarify the change type
+- Provide reasoning for suggested template
+- Offer to show multiple template options
+
+**If JIRA integration fails:**
+- Log a warning but continue with PR creation
+- Use git diff analysis and commit messages as fallback
+- Suggest manual addition of JIRA context if needed
+
+## Anti-patterns to Avoid
+
+- 🚫 Do not omit the JIRA ID prefix from the PR title when a JIRA ID is available
+- 🚫 Do not block PR creation if JIRA API is unavailable — fall back to git diff analysis
+- 🚫 Do not select a template based solely on JIRA issue type; validate against actual git diff
+- 🚫 Do not include Claude co-authorship in the PR body
+
+## Notes
+
+### JIRA Integration
+- **JIRA integration is optional**: If JIRA API is unavailable or fails, the skill continues with git diff analysis only
+- **Git diff is the source of truth for technical details**: JIRA provides business context and requirements
+- **Acceptance Criteria parsing**: Look for common markers in JIRA description:
+  - "*Acceptance Criteria*" (formatted text)
+  - "AC:" or "Acceptance Criteria:"
+  - Bullet points or numbered lists following these markers
+- **Related tickets**: Check JIRA description for links to other tickets (initiatives, dependencies, blockers)
+- The JIRA MCP tool (`mcp__atlassian__jira_get_issue`) requires proper authentication and network access to Jira instance
+- **PR Title**: Prefer JIRA summary but refine if needed for clarity (e.g., translate to English if JIRA is written in another language)
+- **Always include JIRA reference**: Even if JIRA API fails, reference the JIRA ticket ID in the PR description
+
+### Command Templates
+
+**GitHub:**
+```bash
+gh pr create \
+  --base <base_branch> \
+  --draft \
+  --title "[JIRA-ID] Description" \
+  --body "$(cat <<'EOF'
+<PR description here>
+EOF
+)"
+```
+
+**GitLab:**
+```bash
+glab mr create \
+  --source-branch <head_branch> \
+  --target-branch <base_branch> \
+  --draft \
+  --title "[JIRA-ID] Description" \
+  --description "$(cat <<'EOF'
+<PR description here>
+EOF
+)"
+```
+
+## References
+
+- [git-commit](../git-commit/SKILL.md) -- create commits before PR (`git-commit`)
+- [PR templates guide](references/pr-templates-guide.md) -- detailed per-template fill-out guidance
+- [gotchas.md](gotchas.md) - Common Claude anti-patterns when opening PRs

--- a/skills/git-pull-request/assets/templates/bug.md
+++ b/skills/git-pull-request/assets/templates/bug.md
@@ -1,0 +1,18 @@
+## Bug Fix
+
+### Description
+<!-- Brief description of the bug being fixed -->
+
+### Root Cause
+<!-- What caused the bug? -->
+
+### Solution
+<!-- How does this PR fix the bug? -->
+
+### Testing
+- [ ] Added/updated tests
+- [ ] Manually tested the fix
+- [ ] Verified no regressions
+
+### Related Issues
+Fixes #<!-- issue number -->

--- a/skills/git-pull-request/assets/templates/docs.md
+++ b/skills/git-pull-request/assets/templates/docs.md
@@ -1,0 +1,13 @@
+## Documentation Update
+
+### Description
+<!-- What documentation is being updated? -->
+
+### Changes
+<!-- List of specific changes made -->
+
+### Review Checklist
+- [ ] Grammar and spelling checked
+- [ ] Technical accuracy verified
+- [ ] Examples tested
+- [ ] Links verified

--- a/skills/git-pull-request/assets/templates/feature.md
+++ b/skills/git-pull-request/assets/templates/feature.md
@@ -1,0 +1,22 @@
+## New Feature
+
+### Description
+<!-- Brief description of the new feature -->
+
+### Motivation
+<!-- Why is this feature needed? -->
+
+### Implementation
+<!-- High-level overview of the implementation -->
+
+### Testing
+- [ ] Added unit tests
+- [ ] Added integration tests
+- [ ] Tested edge cases
+
+### Documentation
+- [ ] Updated relevant documentation
+- [ ] Added usage examples
+
+### Breaking Changes
+<!-- List any breaking changes -->

--- a/skills/git-pull-request/assets/templates/performance.md
+++ b/skills/git-pull-request/assets/templates/performance.md
@@ -1,0 +1,15 @@
+## Performance Improvement
+
+### Description
+<!-- What performance issue is being addressed? -->
+
+### Metrics
+<!-- Before/after performance metrics -->
+
+### Changes
+<!-- Specific optimizations made -->
+
+### Testing
+- [ ] Benchmarks added/updated
+- [ ] No functionality regression
+- [ ] Tested under various loads

--- a/skills/git-pull-request/assets/templates/refactor.md
+++ b/skills/git-pull-request/assets/templates/refactor.md
@@ -1,0 +1,18 @@
+## Code Refactoring
+
+### Description
+<!-- What code is being refactored? -->
+
+### Motivation
+<!-- Why is this refactoring needed? -->
+
+### Changes
+<!-- List of specific refactoring changes -->
+
+### Testing
+- [ ] All existing tests pass
+- [ ] No functional changes
+- [ ] Performance impact assessed
+
+### Risk Assessment
+<!-- Any risks with this refactoring? -->

--- a/skills/git-pull-request/assets/templates/security.md
+++ b/skills/git-pull-request/assets/templates/security.md
@@ -1,0 +1,18 @@
+## Security Update
+
+### Description
+<!-- Brief description of security issue (be careful not to expose vulnerabilities) -->
+
+### Impact
+<!-- Who/what is affected? -->
+
+### Solution
+<!-- How does this PR address the security issue? -->
+
+### Testing
+- [ ] Security tests added
+- [ ] Penetration testing performed
+- [ ] No new vulnerabilities introduced
+
+### References
+<!-- Link to security advisories if applicable -->

--- a/skills/git-pull-request/assets/templates/test.md
+++ b/skills/git-pull-request/assets/templates/test.md
@@ -1,0 +1,16 @@
+## Test Update
+
+### Description
+<!-- What tests are being added or updated? -->
+
+### Coverage
+- Previous coverage: <!-- X% -->
+- New coverage: <!-- Y% -->
+
+### Test Types
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] End-to-end tests
+
+### Related Features
+<!-- List features/components being tested -->

--- a/skills/git-pull-request/config.json
+++ b/skills/git-pull-request/config.json
@@ -1,0 +1,5 @@
+{
+  "default_base_branch": "develop",
+  "jira_project_prefix": "",
+  "pr_platform": ""
+}

--- a/skills/git-pull-request/references/pr-templates-guide.md
+++ b/skills/git-pull-request/references/pr-templates-guide.md
@@ -1,0 +1,112 @@
+# PR Templates Guide
+
+Detailed guidance for filling out each PR template using JIRA context and git diff analysis.
+
+## Template Assets
+
+Available templates in `assets/templates/`:
+- `bug.md`: Bug fix template
+- `feature.md`: New feature template
+- `docs.md`: Documentation template
+- `refactor.md`: Refactoring template
+- `test.md`: Test addition template
+- `performance.md`: Performance optimization template
+- `security.md`: Security fix template
+
+## Per-Template Fill-Out Guidance
+
+### bug.md
+
+- **Issue Description**: Extract from JIRA description + git diff analysis
+- **Root Cause**: Technical reason from code analysis
+- **Fix Description**: Changes from git diff + JIRA acceptance criteria
+- **Testing**: How the fix was verified + JIRA test requirements
+- **Related Issues**: Reference the JIRA ticket ID (e.g., `JIRA-ID`). If the JIRA server URL is known, include a full link.
+
+### feature.md
+
+- **Description**: JIRA summary + technical details from git diff
+- **Motivation**: Extract from JIRA description (business context, user needs)
+- **Implementation**: High-level approach from git diff analysis
+- **Acceptance Criteria**: Parse from JIRA description (look for bullet points, numbered lists)
+- **Testing**: Test coverage details + JIRA test scenarios
+- **Related Issues**: Link to JIRA ticket and any dependencies mentioned
+
+### refactor.md
+
+- **Motivation**: JIRA description (technical debt context) + why refactoring needed
+- **Changes Made**: What was restructured from git diff
+- **Impact**: How behavior is preserved or improved
+- **Related Issues**: Link to JIRA technical debt ticket
+
+### docs.md
+
+- **Documentation Updates**: What was changed/added from git diff
+- **Impact**: Who benefits (from JIRA context if available)
+- **Related Issues**: Link to JIRA documentation task
+
+### test.md
+
+- **Test Coverage**: What scenarios are now tested
+- **Test Type**: Unit, integration, or end-to-end tests
+- **Coverage Improvements**: Metrics if available
+- **Related Issues**: Link to JIRA test task
+
+### performance.md
+
+- **Performance Issue**: What was slow (from JIRA if mentioned)
+- **Optimization**: Changes made from git diff
+- **Metrics**: Before/after measurements if available
+- **Related Issues**: Link to JIRA performance ticket
+
+### security.md
+
+- **Vulnerability**: Security issue from JIRA + technical details
+- **Fix**: How the vulnerability was mitigated
+- **Impact**: Severity and affected versions from JIRA
+- **Related Issues**: Link to JIRA security ticket
+
+## Example PR Description
+
+Combining JIRA context with git diff analysis:
+
+```markdown
+# [PROJ-123] Migrate external service integration to v2
+
+## Description
+Migrates the external service integration from v1 to v2 API endpoints. This update is required to support the new data model where resources are now separate entities instead of being nested within categories.
+
+## Motivation
+The external service team has deprecated v1 endpoints and requires all consumers to migrate to v2. The new version provides better separation of concerns and improved data modeling.
+
+**JIRA Context**: Service v1 endpoints are being migrated to v2 across all consumers. This is part of the larger initiative tracked in PROJ-100.
+
+## Implementation
+- Updated rest client dependency to v2.0.0
+- Refactored domain model to accommodate new API contract
+- Updated repository adapters and mappers for v2 endpoints
+- Extracted related entities into separate domain objects
+- Updated configuration across all environments
+- Updated tests to reflect new data model
+
+## Acceptance Criteria
+- [x] All v1 endpoints replaced with v2 equivalents
+- [x] Contracts maintained (no breaking changes to our API)
+- [x] New entities properly extracted
+- [x] Configuration updated for all environments
+- [x] All tests passing with new data model
+
+## Testing
+- Unit tests updated for new domain model
+- Integration tests updated for v2 API contract
+- All existing tests passing
+- Manual testing in staging environment
+
+## Related Issues
+- JIRA: PROJ-123
+- Initiative: PROJ-100
+
+## Files Changed
+- 20 files modified
+- 84 insertions, 172 deletions
+```


### PR DESCRIPTION
## Summary

Bring the catalog's git skills to parity with the polished versions maintained in `lib-purchaseai/agents/shared/skills`. Previously both skills were 56-line shims — process summary + short rules list — which had lost most of the original authoring.

### What lands

- **`git-commit`** — Pre-resolved dynamic context (branch/status/diff/log), JIRA-ID extraction from branch names + MCP lookup, 9-step workflow covering type detection, scope derivation, breaking-change detection, description generation, and verification. New `references/commit-patterns.md` + `references/commit-examples.md`, `config.json` (`default_base_branch`, `jira_project_prefix`), and `scripts/branch-to-jira.sh` helper.
- **`git-pull-request`** — Platform auto-detection (GitHub `gh` / GitLab `glab`), JIRA-driven PR template selection, 10-step workflow with draft-by-default and title/body validation checklist. New `references/pr-templates-guide.md`, `config.json` (platform override), and seven PR templates under `assets/templates/`: bug, feature, docs, refactor, test, performance, security.

### Meta improvements (both skills)

- **Broader `When to Invoke`** with intent-based matching in English **and** Spanish (plus indirect-cue detection). The agent now routes paraphrases like *"haz commit"* or *"si crea el pr"* to the skill without the user typing a specific trigger phrase. Regression context: we hit exactly this miss when testing the Copilot model routing flow — the agent saw *"si crea el pr"* and fell back to generic PR-open instead of invoking the skill.
- **`model: haiku`** — these skills are mechanical (diff parsing, branch regex, template rendering, CLI orchestration); no need for a heavier reasoning model.
- **Preserved existing `gotchas.md`** on both skills (they capture broader Claude anti-patterns that complement the technical `## Gotchas` section inside `SKILL.md`) and reference them explicitly from the skill body.

## Test Plan

- [x] Staging only touches `skills/git-commit/` and `skills/git-pull-request/` — other untracked files in the worktree excluded.
- [x] Frontmatter sanity: both files have `name: <hyphen>`, `model: haiku`, expanded `allowed-tools` with granular `Bash(...)` patterns and `mcp__atlassian__jira_get_issue`.
- [x] Supporting dirs land with the right layout: `references/`, `scripts/` (with `branch-to-jira.sh` executable), `assets/templates/*.md`.
- [x] Post-merge: a `devrune install` in a consumer project should materialise the enriched SKILL.md into its `.claude/skills/`, and Claude Code should recognise the broader triggers on the next session.
- [x] Manual smoke: in a fresh consumer repo, typing *"haz commit"* should route to the skill; typing *"si crea el pr"* should route to git-pull-request.