### PR TITLE
fix(sdd): complete adviser→advisor rename in workflow + skills

### DIFF
--- a/skills/api-first-advisor/SKILL.md
+++ b/skills/api-first-advisor/SKILL.md
@@ -6,7 +6,7 @@ version: "1.0"
 tags: [api, openapi, rest, http, versioning, error-handling]
 ---
 
-# API-First Adviser Skill
+# API-First Advisor Skill
 
 Guide API design using an API-first approach: define the contract in OpenAPI before writing implementation code. Apply consistent REST conventions, proper HTTP semantics, RFC 7807 error models, and versioning strategies.
 
@@ -82,25 +82,25 @@ Before finalizing your review, check `gotchas.md` for common Claude mistakes in 
 - [ ] `Location` header returned on 201 Created responses
 - [ ] Deprecation communicated via `Sunset` and `Deprecation` headers
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
-3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In adviser mode, focus on contract specs and API shape from the plan (not codebase files).
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In advisor mode, focus on contract specs and API shape from the plan (not codebase files).
 4. Produce structured advice in the format below.
 5. Save output to engram and return summary + observation ID.
 
 Focus ONLY on your specialist domain: REST conventions, OpenAPI spec quality, error models, versioning.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -114,11 +114,11 @@ Focus ONLY on your specialist domain: REST conventions, OpenAPI spec quality, er
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/api-first-adviser",
+  title: "sdd/{change-name}/guidance/api-first-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -126,7 +126,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -137,4 +137,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/api-first-advisor/gotchas.md
+++ b/skills/api-first-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — api-first-adviser
+# Gotchas — api-first-advisor
 
 Common mistakes Claude makes when designing or reviewing APIs. Check these before finalizing your output.
 

--- a/skills/architect-advisor/SKILL.md
+++ b/skills/architect-advisor/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 model: sonnet
 ---
 
-# architect-adviser
+# architect-advisor
 
 Provide expert guidance on clean architecture patterns, hexagonal architecture, and Domain-Driven Design.
 
@@ -96,16 +96,16 @@ Structure findings as:
 
 Before finalizing your review, check `gotchas.md` for common Claude mistakes in this domain.
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
 3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
@@ -114,7 +114,7 @@ Adviser mode is active when the prompt contains:
 
 Focus ONLY on your specialist domain: Architecture patterns, layer separation, dependency flow, DDD tactical patterns.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -128,11 +128,11 @@ Focus ONLY on your specialist domain: Architecture patterns, layer separation, d
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/architect-adviser",
+  title: "sdd/{change-name}/guidance/architect-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -140,7 +140,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -151,4 +151,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/architect-advisor/gotchas.md
+++ b/skills/architect-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — architect-adviser
+# Gotchas — architect-advisor
 
 Common mistakes Claude makes when reviewing or advising on architecture. Check these before finalizing your output.
 

--- a/skills/component-advisor/SKILL.md
+++ b/skills/component-advisor/SKILL.md
@@ -6,7 +6,7 @@ version: "1.0"
 tags: [react, components, hooks, design-patterns, performance]
 ---
 
-# Component Adviser Skill
+# Component Advisor Skill
 
 Guide React component design toward maintainable, composable, and performant patterns. Apply composition principles, proper hooks usage, and clear prop contracts to produce components that are easy to test and extend.
 
@@ -82,16 +82,16 @@ When reviewing React components:
 - [ ] Components are composable — children/render props used for extensibility
 - [ ] No business logic in components (use hooks or services)
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
 3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
@@ -100,7 +100,7 @@ Adviser mode is active when the prompt contains:
 
 Focus ONLY on your specialist domain: React component patterns, hooks, props design, state management.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -114,11 +114,11 @@ Focus ONLY on your specialist domain: React component patterns, hooks, props des
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/component-adviser",
+  title: "sdd/{change-name}/guidance/component-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -126,7 +126,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -137,4 +137,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/component-advisor/gotchas.md
+++ b/skills/component-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — component-adviser
+# Gotchas — component-advisor
 
 Common mistakes Claude makes when writing or reviewing React components. Check these before finalizing your output.
 

--- a/skills/frontend-test-advisor/SKILL.md
+++ b/skills/frontend-test-advisor/SKILL.md
@@ -6,7 +6,7 @@ version: "1.0"
 tags: [testing, react, rtl, vitest, jest, cypress, frontend]
 ---
 
-# Frontend Test Adviser Skill
+# Frontend Test Advisor Skill
 
 Guide frontend testing strategy using React Testing Library (RTL), Vitest/Jest, and Cypress. Focus on testing behavior from the user's perspective rather than implementation details.
 
@@ -58,16 +58,16 @@ When reviewing frontend tests:
 - [ ] Error and loading states covered
 - [ ] Accessibility attributes tested (role, name, disabled state)
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
 3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
@@ -76,7 +76,7 @@ Adviser mode is active when the prompt contains:
 
 Focus ONLY on your specialist domain: RTL queries, user-event, MSW mocking, test structure.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -90,11 +90,11 @@ Focus ONLY on your specialist domain: RTL queries, user-event, MSW mocking, test
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/frontend-test-adviser",
+  title: "sdd/{change-name}/guidance/frontend-test-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -102,7 +102,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -113,4 +113,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/frontend-test-advisor/gotchas.md
+++ b/skills/frontend-test-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — frontend-test-adviser
+# Gotchas — frontend-test-advisor
 
 Common mistakes Claude makes when writing or reviewing frontend tests. Check these before finalizing your output.
 

--- a/skills/integration-test-advisor/SKILL.md
+++ b/skills/integration-test-advisor/SKILL.md
@@ -6,7 +6,7 @@ version: "1.0"
 tags: [testing, integration-tests, adapters, mocking, database]
 ---
 
-# Integration Test Adviser Skill
+# Integration Test Advisor Skill
 
 Guide the design of integration tests that verify how components collaborate across boundaries — specifically how adapters interact with databases, external HTTP services, and messaging systems.
 
@@ -52,25 +52,25 @@ When reviewing integration tests:
 - [ ] Tests don't depend on execution order (no shared mutable state between tests)
 - [ ] Assertions verify the actual stored/transmitted state, not just return values
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
-3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In adviser mode, focus on adapter boundaries and test slicing as described in plan tasks.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In advisor mode, focus on adapter boundaries and test slicing as described in plan tasks.
 4. Produce structured advice in the format below.
 5. Save output to engram and return summary + observation ID.
 
 Focus ONLY on your specialist domain: @AdapterIT patterns, SimulationRepository, external service mocking.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -84,11 +84,11 @@ Focus ONLY on your specialist domain: @AdapterIT patterns, SimulationRepository,
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/integration-test-adviser",
+  title: "sdd/{change-name}/guidance/integration-test-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -96,7 +96,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -107,4 +107,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/integration-test-advisor/gotchas.md
+++ b/skills/integration-test-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — integration-test-adviser
+# Gotchas — integration-test-advisor
 
 Common mistakes Claude makes when writing or reviewing integration tests. Check these before finalizing your output.
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -26,7 +26,7 @@ This skill reads `config.json` from its own directory:
 ## Overview
 
 This skill orchestrates PR/MR code reviews in 3 steps:
-1. **Delegate** — a single sub-agent detects the platform, fetches the PR/MR, creates an isolated worktree, and analyzes using `sdd-review` with dynamic adviser discovery. Returns a structured JSON.
+1. **Delegate** — a single sub-agent detects the platform, fetches the PR/MR, creates an isolated worktree, and analyzes using `sdd-review` with dynamic advisor discovery. Returns a structured JSON.
 2. **Review with user** — present findings for user approval before publishing (human-in-the-loop)
 3. **Publish** — post only user-approved findings as inline comments on the detected platform
 
@@ -129,7 +129,7 @@ git -C /tmp/pr-review-<pr-number> checkout pr-review-<pr-number>
 
 Load the sdd-review skill via the Skill tool: Skill("sdd-review"). Follow its Standalone Mode instructions (no change_name).
 
-When the skill says to check for *-adviser skills, discover and invoke them via the Skill tool (advisers ARE slash commands).
+When the skill says to check for *-advisor skills, discover and invoke them via the Skill tool (advisors ARE slash commands).
 
 {if focus provided:}
 ## Review Focus (PRIORITY)
@@ -159,14 +159,14 @@ Return ONLY this JSON (no other text):
   "summary": "Brief assessment",
   "verdict": "APPROVE | COMMENT | REQUEST_CHANGES",
   "highlights": ["Positive 1", "Positive 2"],
-  "advisers_used": ["architect-adviser", "unit-test-adviser"],
+  "advisors_used": ["architect-advisor", "unit-test-advisor"],
   "findings": [
     {
       "path": "relative/path/to/file.java",
       "line": 63,
       "severity": "Critical | Major | Minor | Suggestion",
       "category": "Architecture | Code Quality | Testing | Bug Risk | Performance | Security | Business Logic",
-      "rule": "adviser or rule name",
+      "rule": "advisor or rule name",
       "body": "Description with suggestion"
     }
   ]
@@ -200,7 +200,7 @@ Present:
 1. **Platform**: GitHub / GitLab
 2. **Verdict**: APPROVE / COMMENT / REQUEST_CHANGES
 3. **Summary**: One-line assessment
-4. **Advisers used**: Which `*-adviser` skills contributed
+4. **Advisors used**: Which `*-advisor` skills contributed
 5. **Highlights**: What the PR/MR does well
 6. **Findings table**:
 
@@ -262,13 +262,13 @@ glab api projects/:id/merge_requests/<pr-number>/discussions \
 
 **Rules (both platforms):**
 - Comments and summary in the **user's language**
-- Review body includes: summary, advisers applied, highlights, verdict, footer `Generated with [Claude Code](https://claude.com/claude-code)`
+- Review body includes: summary, advisors applied, highlights, verdict, footer `Generated with [Claude Code](https://claude.com/claude-code)`
 - GitHub event MUST be `"COMMENT"`
 - Max `max_comments` findings (default: 20), prioritized by severity
 
 ### Step 5: Report to User
 
-Display: platform, advisers used, comments posted count, findings by severity, PR/MR link, verdict.
+Display: platform, advisors used, comments posted count, findings by severity, PR/MR link, verdict.
 
 ## Gotchas
 
@@ -290,7 +290,7 @@ See `gotchas.md` in this skill directory for the full list. Key points:
 | Error | Action |
 |-------|--------|
 | PR/MR not found | Tell user the number may be wrong or they lack access |
-| No adviser skills installed | Proceed with general review only |
+| No advisor skills installed | Proceed with general review only |
 | Diff too large (>5000 lines) | Warn and proceed — suggest batch review |
 | Sub-agent returns invalid JSON | Parse what you can; post valid findings, report errors |
 | GitHub API error posting review | Show error and dump review as text for manual posting |
@@ -302,6 +302,6 @@ See `gotchas.md` in this skill directory for the full list. Key points:
 
 ## References
 
-- `sdd-review` — core analysis engine (standalone mode) with dynamic adviser discovery
+- `sdd-review` — core analysis engine (standalone mode) with dynamic advisor discovery
 - `git-pull-request` — PR/MR creation (complementary: create → review)
 - `git-commit` — commit automation (complementary: review → commit)

--- a/skills/review-pr/gotchas.md
+++ b/skills/review-pr/gotchas.md
@@ -20,7 +20,7 @@ Security policy blocks all compound `cd && git/gh` commands (even for `/tmp`). U
 
 ## Sub-agent must load sdd-review via Skill tool
 
-The sub-agent loads sdd-review using `Skill("sdd-review")` — not by reading the SKILL.md file manually. Advisers (`*-adviser`) are also loaded via the Skill tool.
+The sub-agent loads sdd-review using `Skill("sdd-review")` — not by reading the SKILL.md file manually. Advisors (`*-advisor`) are also loaded via the Skill tool.
 
 ## Keep orchestrator context clean
 

--- a/skills/unit-test-advisor/SKILL.md
+++ b/skills/unit-test-advisor/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 model: sonnet
 ---
 
-# unit-test-adviser
+# unit-test-advisor
 
 Provide expert guidance on writing effective unit tests for domain logic following Given-When-Then structure.
 
@@ -95,25 +95,25 @@ Every test class should cover:
 
 Before finalizing your review, check `gotchas.md` for common Claude mistakes in this domain.
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
-3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In adviser mode, focus on test scope and coverage gaps identified in the plan's Testing section.
+3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant. In advisor mode, focus on test scope and coverage gaps identified in the plan's Testing section.
 4. Produce structured advice in the format below.
 5. Save output to engram and return summary + observation ID.
 
 Focus ONLY on your specialist domain: Test structure, mocking strategies, Mother pattern, Given-When-Then.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -127,11 +127,11 @@ Focus ONLY on your specialist domain: Test structure, mocking strategies, Mother
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/unit-test-adviser",
+  title: "sdd/{change-name}/guidance/unit-test-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -139,7 +139,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -150,4 +150,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/unit-test-advisor/gotchas.md
+++ b/skills/unit-test-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — unit-test-adviser
+# Gotchas — unit-test-advisor
 
 Common mistakes Claude makes when writing or reviewing unit tests. Check these before finalizing your output.
 

--- a/skills/web-accessibility-advisor/SKILL.md
+++ b/skills/web-accessibility-advisor/SKILL.md
@@ -6,7 +6,7 @@ version: "1.0"
 tags: [accessibility, a11y, wcag, aria, keyboard, screen-reader]
 ---
 
-# Accessibility Adviser Skill
+# Accessibility Advisor Skill
 
 Review and guide web accessibility implementation to meet WCAG 2.1 Level AA compliance. Focus on semantic HTML, ARIA usage, keyboard navigation, and screen reader compatibility.
 
@@ -42,16 +42,16 @@ Before finalizing your review, check `gotchas.md` for common Claude mistakes in 
 - [ ] Skip navigation link provided
 - [ ] ARIA roles match the interaction model of custom widgets
 
-## Adviser Mode (SDD Orchestrator Integration)
+## Advisor Mode (SDD Orchestrator Integration)
 
-This skill supports **adviser mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
+This skill supports **advisor mode**: when invoked by the SDD orchestrator with a `GUIDANCE CONTEXT FROM PLANNER` block in the prompt, use the following procedure instead of the standard interactive review flow.
 
 ### Entry Conditions
-Adviser mode is active when the prompt contains:
+Advisor mode is active when the prompt contains:
 - A `GUIDANCE CONTEXT FROM PLANNER:` block
 - A `CURRENT PLAN EXCERPT:` block
 
-### Adviser Mode Procedure
+### Advisor Mode Procedure
 1. Read the `GUIDANCE CONTEXT FROM PLANNER` block to understand what the planner needs reviewed.
 2. Read the `CURRENT PLAN EXCERPT` to see the specific tasks and design decisions.
 3. Apply your domain expertise to the plan content — do NOT read codebase files unless the plan references specific existing code that is relevant.
@@ -60,7 +60,7 @@ Adviser mode is active when the prompt contains:
 
 Focus ONLY on your specialist domain: WCAG 2.1 AA, ARIA patterns, keyboard navigation, focus management.
 
-### Output Format (Adviser Mode)
+### Output Format (Advisor Mode)
 ```
 ### Strengths
 - [What looks sound in the plan from this skill's domain perspective]
@@ -74,11 +74,11 @@ Focus ONLY on your specialist domain: WCAG 2.1 AA, ARIA patterns, keyboard navig
 - T001: [recommendation]
 ```
 
-### Persistence (Adviser Mode)
+### Persistence (Advisor Mode)
 Save full advice output to engram:
 ```
 mem_save(
-  title: "sdd/{change-name}/guidance/web-accessibility-adviser",
+  title: "sdd/{change-name}/guidance/web-accessibility-advisor",
   type: "architecture",
   project: "{project-name}",
   content: "{your full structured advice output}"
@@ -86,7 +86,7 @@ mem_save(
 ```
 If engram is unavailable, skip silently.
 
-### Return Format (Adviser Mode)
+### Return Format (Advisor Mode)
 Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ```
 ### Summary
@@ -97,4 +97,4 @@ Return a concise summary (3-5 bullet points) plus the engram observation ID:
 ### Engram ID
 {observation_id or "unavailable"}
 ```
-Do NOT return an SDD Envelope when in adviser mode.
+Do NOT return an SDD Envelope when in advisor mode.

--- a/skills/web-accessibility-advisor/gotchas.md
+++ b/skills/web-accessibility-advisor/gotchas.md
@@ -1,4 +1,4 @@
-# Gotchas — web-accessibility-adviser
+# Gotchas — web-accessibility-advisor
 
 Common mistakes Claude makes when implementing or reviewing web accessibility. Check these before finalizing your output.
 

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -30,7 +30,7 @@ For each phase, launch via the `Agent` tool:
 
 ```
 Agent(
-  description: '{phase} for {change-name}',  # required — 3-5 words, e.g. "explore for sdd-advisers-command"
+  description: '{phase} for {change-name}',  # required — 3-5 words, e.g. "explore for sdd-advisors-command"
   subagent_type: 'sdd-{phase}',             # sdd-explorer, sdd-planner, sdd-implementer, sdd-reviewer
   run_in_background: false,                 # true ONLY for parallel implement batches (see below)
   prompt: <dynamic context — see per-phase blocks>
@@ -70,27 +70,27 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 4. **Show** executive summary to user (verbatim from envelope). For parallel waves: per-batch status first, then aggregated wave status.
 
 5. **Guidance loop** (plan phase only): After `plan` returns `status: guidance_requested`:
-   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   a. Extract `requested_advisors[]` and `guidance_context` from envelope.
    b. Increment `guidance_round` in state.yaml (for tracking only — no maximum).
-   c. Launch all advisers in parallel. **Launch all requested advisers in a single message with multiple Agent() calls, each with `run_in_background: true`** — running N background tasks sequentially does NOT run them in parallel.
+   c. Launch all advisors in parallel. **Launch all requested advisors in a single message with multiple Agent() calls, each with `run_in_background: true`** — running N background tasks sequentially does NOT run them in parallel.
       ```
       Agent(
-        description: '{adviser-skill} guidance for {change-name}',  # required
-        subagent_type: '{adviser-skill}',              # e.g. architect-adviser, api-first-adviser
+        description: '{advisor-skill} guidance for {change-name}',  # required
+        subagent_type: '{advisor-skill}',              # e.g. architect-advisor, api-first-advisor
         run_in_background: true,
         prompt: 'Review the plan at .sdd/{change}/plan.md from your specialist perspective.
-          Focus: {guidance_context_for_this_adviser}.
+          Focus: {guidance_context_for_this_advisor}.
           Provide Strengths / Issues Found / Recommendations format, return engram observation ID.
           Persist findings via mem_save.'
       )
       ```
-   d. Wait for all adviser background tasks to complete (Claude Code sends notifications). If an adviser reports engram unavailable: keep its returned inline summary text for step f.
-   e. Collect each adviser's engram observation ID (or inline summary if engram unavailable).
+   d. Wait for all advisor background tasks to complete (Claude Code sends notifications). If an advisor reports engram unavailable: keep its returned inline summary text for step f.
+   e. Collect each advisor's engram observation ID (or inline summary if engram unavailable).
    f. Re-launch `sdd-planner` with a GUIDANCE block. Show BOTH forms explicitly — planner fetches engram IDs via `mem_get_observation`, reads inline text as-is:
       ```
       GUIDANCE (Round N):
-      - architect-adviser: engram ID {id} — {one-line summary}    # engram available → planner calls mem_get_observation({id})
-      - api-first-adviser: [inline] {full adviser text}            # engram unavailable → planner reads inline text directly
+      - architect-advisor: engram ID {id} — {one-line summary}    # engram available → planner calls mem_get_observation({id})
+      - api-first-advisor: [inline] {full advisor text}            # engram unavailable → planner reads inline text directly
       ```
    g. Loop back to step 1 with the planner's new envelope.
    - After non-plan phases or `status: ok/warning/blocked/failed`: skip this step.

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -22,7 +22,7 @@
 | plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
 | implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
 | review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
-| adviser | `*-adviser` | `{WORKFLOW_MODEL_ADVISER}` ⭐ | N/A — Copilot uses natural language @agent-name invocation, not Task() |
+| advisor | `*-advisor` | `{WORKFLOW_MODEL_ADVISOR}` ⭐ | N/A — Copilot uses natural language @agent-name invocation, not Task() |
 
 ## Evaluation Gate
 
@@ -81,16 +81,16 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
-   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   a. Extract `requested_advisors[]` and `guidance_context` from envelope.
    b. Increment `guidance_round` in state.yaml.
-   c. For each requested adviser: invoke `@{adviser-skill}` by name (e.g. `@architect-adviser`,
-      `@api-first-adviser`) with the prompt from the Copilot Adviser Invocation template in
-      `{WORKFLOW_DIR}/_shared/adviser-templates.md`. This is natural language @agent-name invocation — the same
-      mechanism used to invoke `@sdd-planner` and `@sdd-explorer`. Each adviser is a `.agent.md`
+   c. For each requested advisor: invoke `@{advisor-skill}` by name (e.g. `@architect-advisor`,
+      `@api-first-advisor`) with the prompt from the Copilot Advisor Invocation template in
+      `{WORKFLOW_DIR}/_shared/advisor-templates.md`. This is natural language @agent-name invocation — the same
+      mechanism used to invoke `@sdd-planner` and `@sdd-explorer`. Each advisor is a `.agent.md`
       file in `.github/agents/` and loads its SKILL.md directly (no Skill() tool required).
-   d. Run advisers sequentially (Copilot has no background execution).
-      Collect each summary + engram ID before invoking the next adviser.
-   e. Invoke `@sdd-planner` with the Plan Re-entry with Guidance format (see `{WORKFLOW_DIR}/_shared/adviser-templates.md`).
+   d. Run advisors sequentially (Copilot has no background execution).
+      Collect each summary + engram ID before invoking the next advisor.
+   e. Invoke `@sdd-planner` with the Plan Re-entry with Guidance format (see `{WORKFLOW_DIR}/_shared/advisor-templates.md`).
    f. After `@sdd-planner` returns: loop back to step 1.
    - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
 6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -23,7 +23,7 @@
 | plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
 | implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
 | review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
-| adviser | `*-adviser` | `{WORKFLOW_MODEL_ADVISER}` ⭐ | `general-purpose` (hardcoded) |
+| advisor | `*-advisor` | `{WORKFLOW_MODEL_ADVISOR}` ⭐ | `general-purpose` (hardcoded) |
 
 ## Evaluation Gate
 
@@ -74,19 +74,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
-   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   a. Extract `requested_advisors[]` and `guidance_context` from envelope.
    b. Increment `guidance_round` in state.yaml (for tracking only — no maximum).
-   c. Launch all advisers in parallel using the Adviser Consultation Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`. Use `run_in_background: true` for each.
-   d. Wait for all adviser background tasks to complete.
-   e. Collect the summary and engram observation ID returned by each adviser.
-      (Each adviser persists its own output to engram and returns the observation ID.)
-      If an adviser reports engram unavailable: keep its returned inline summary text for step f.
-   f. Re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`.
-      - For each adviser: include its observation ID in the GUIDANCE block (planner fetches full content via mem_get_observation).
-      - If engram unavailable for an adviser: include its inline summary text in the GUIDANCE block instead.
+   c. Launch all advisors in parallel using the Advisor Consultation Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`. Use `run_in_background: true` for each.
+   d. Wait for all advisor background tasks to complete.
+   e. Collect the summary and engram observation ID returned by each advisor.
+      (Each advisor persists its own output to engram and returns the observation ID.)
+      If an advisor reports engram unavailable: keep its returned inline summary text for step f.
+   f. Re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+      - For each advisor: include its observation ID in the GUIDANCE block (planner fetches full content via mem_get_observation).
+      - If engram unavailable for an advisor: include its inline summary text in the GUIDANCE block instead.
    g. After sdd-plan re-entry returns envelope: loop back to step 1 (Post-Phase Protocol from start).
    - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
-   - The guidance loop runs as many times as sdd-plan requests guidance_requested. The user controls plan quality via crit review — if during a crit iteration the planner needs more adviser input, it can request guidance again.
+   - The guidance loop runs as many times as sdd-plan requests guidance_requested. The user controls plan quality via crit review — if during a crit iteration the planner needs more advisor input, it can request guidance again.
 6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).
    - If crit is found: auto-launch Crit Plan Review Protocol (see dedicated section below). Skip step 7.
    - If crit is NOT found: proceed to step 7 (existing flow, no behavioral change).

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -22,7 +22,7 @@
 | plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
 | implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
 | review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
-| adviser | `*-adviser` | `{WORKFLOW_MODEL_ADVISER}` ⭐ | `general-purpose` (hardcoded) |
+| advisor | `*-advisor` | `{WORKFLOW_MODEL_ADVISOR}` ⭐ | `general-purpose` (hardcoded) |
 
 ## Evaluation Gate
 
@@ -73,12 +73,12 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 4. **Show** executive summary to user (verbatim from envelope). For parallel implement waves: show per-batch status first, then the aggregated wave status.
 5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
-   a. Extract `requested_advisers[]` and `guidance_context` from envelope.
+   a. Extract `requested_advisors[]` and `guidance_context` from envelope.
    b. Increment `guidance_round` in state.yaml.
-   c. **Launch advisers sequentially** (OpenCode does not support run_in_background) using the
-      Sequential Adviser Consultation Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`.
-      Run one adviser at a time; collect each summary + engram ID before launching the next.
-   d. After all advisers complete: re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/adviser-templates.md`.
+   c. **Launch advisors sequentially** (OpenCode does not support run_in_background) using the
+      Sequential Advisor Consultation Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+      Run one advisor at a time; collect each summary + engram ID before launching the next.
+   d. After all advisors complete: re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
    e. After sdd-plan re-entry returns envelope: loop back to step 1 (Post-Phase Protocol from start).
    - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
 6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit` (Bash).

--- a/workflows/sdd/_shared/advisor-templates.md
+++ b/workflows/sdd/_shared/advisor-templates.md
@@ -1,31 +1,31 @@
-# SDD Adviser Templates
+# SDD Advisor Templates
 
 These templates are used by the orchestrator when handling `guidance_requested` envelopes.
 See `launch-templates.md` for phase launch templates (explore, plan, implement, review).
 
-## Adviser Consultation Template
+## Advisor Consultation Template
 
 > **Multi-agent compatibility note**: This template is for Claude and Factory agents (Task() + run_in_background supported).
-> OpenCode: use the Sequential Adviser Template below (run_in_background: false, one at a time).
-> Copilot: use the Copilot Adviser Invocation section below (@agent-name pattern, no Task() tool).
+> OpenCode: use the Sequential Advisor Template below (run_in_background: false, one at a time).
+> Copilot: use the Copilot Advisor Invocation section below (@agent-name pattern, no Task() tool).
 > Codex: same template as Claude/Factory — Task() is supported; run_in_background: false (no background support).
 
-Use this template for each adviser when the orchestrator handles a `guidance_requested` envelope.
-Launch all requested advisers in parallel (run_in_background: true).
+Use this template for each advisor when the orchestrator handles a `guidance_requested` envelope.
+Launch all requested advisors in parallel (run_in_background: true).
 
 Task(
-  description: 'adviser consultation ({adviser-skill}) for {change-name}',
-  subagent_type: 'general-purpose',    // hardcoded — advisers are always general-purpose Task() calls
-  model: '{WORKFLOW_MODEL_ADVISER}',
+  description: 'advisor consultation ({advisor-skill}) for {change-name}',
+  subagent_type: 'general-purpose',    // hardcoded — advisors are always general-purpose Task() calls
+  model: '{WORKFLOW_MODEL_ADVISOR}',
   run_in_background: true,
-  prompt: 'You are a specialist adviser sub-agent. Load your skill:
+  prompt: 'You are a specialist advisor sub-agent. Load your skill:
 
-  Skill(skill: "{adviser-skill}", args: "{change-name}")
+  Skill(skill: "{advisor-skill}", args: "{change-name}")
 
   If the Skill tool fails, fall back to reading the SKILL.md file directly:
-  Read("{SKILLS_PATH}/skills/{adviser-skill}/SKILL.md")
+  Read("{SKILLS_PATH}/skills/{advisor-skill}/SKILL.md")
   (e.g. for Codex/Copilot where Skill() is unavailable — reading the file gives the same instructions)
-  If neither Skill() nor the file read succeeds, use your built-in domain knowledge for this adviser role.
+  If neither Skill() nor the file read succeeds, use your built-in domain knowledge for this advisor role.
 
   CONTEXT:
   - Change: {change-name}
@@ -56,7 +56,7 @@ Task(
   PERSISTENCE:
   Save your full advice output to engram:
   mem_save(
-    title: "sdd/{change-name}/guidance/{adviser-skill}",
+    title: "sdd/{change-name}/guidance/{advisor-skill}",
     type: "architecture",
     project: "{project-name}",
     content: "{your full structured advice output}"
@@ -74,36 +74,36 @@ Task(
   Do NOT produce an SDD Envelope.'
 )
 
-## Sequential Adviser Consultation Template (OpenCode / Codex)
+## Sequential Advisor Consultation Template (OpenCode / Codex)
 
 > Use this template instead of the parallel template above when `run_in_background` is NOT supported
-> (OpenCode, Codex). Launch advisers one at a time, foreground.
+> (OpenCode, Codex). Launch advisors one at a time, foreground.
 
 Task(
-  description: 'adviser consultation ({adviser-skill}) for {change-name}',
+  description: 'advisor consultation ({advisor-skill}) for {change-name}',
   subagent_type: 'general-purpose',
-  model: '{WORKFLOW_MODEL_ADVISER}',
+  model: '{WORKFLOW_MODEL_ADVISOR}',
   run_in_background: false,   // OpenCode/Codex: foreground only
   prompt: '...same prompt body as parallel template above...'
 )
 
-Run each adviser sequentially. Wait for each to return before launching the next.
+Run each advisor sequentially. Wait for each to return before launching the next.
 
-## Copilot Adviser Invocation
+## Copilot Advisor Invocation
 
 > Copilot has no Task() tool. Use natural language @agent-name invocations instead — exactly the same
 > mechanism the orchestrator uses to invoke `@sdd-planner` and `@sdd-explorer`.
 >
 > **Why @agent-name (not #runSubagent)**: `#runSubagent` is VS Code-specific and less portable.
 > Natural language `@agent-name` invocation is the standard Copilot subagent mechanism and matches
-> the existing SDD phase pattern. Each adviser is a `.agent.md` file in `.github/agents/`.
+> the existing SDD phase pattern. Each advisor is a `.agent.md` file in `.github/agents/`.
 >
-> Invoke advisers sequentially (no background execution in Copilot).
+> Invoke advisors sequentially (no background execution in Copilot).
 
-Invoke each requested adviser by naming it in your message:
+Invoke each requested advisor by naming it in your message:
 ```
-@{adviser-skill} You are a specialist adviser. Load your skill by reading:
-{SKILLS_PATH}/{adviser-skill}/SKILL.md
+@{advisor-skill} You are a specialist advisor. Load your skill by reading:
+{SKILLS_PATH}/{advisor-skill}/SKILL.md
 
 GUIDANCE CONTEXT FROM PLANNER:
 {guidance_context from envelope}
@@ -115,14 +115,14 @@ Focus on sections relevant to your domain; the guidance_context tells you WHERE 
 Provide advice in Strengths / Issues Found / Recommendations format.
 Save to engram if available. Return summary + engram ID.
 ```
-Example invocations: `@architect-adviser`, `@api-first-adviser`, `@unit-test-adviser`, etc.
+Example invocations: `@architect-advisor`, `@api-first-advisor`, `@unit-test-advisor`, etc.
 Each `.agent.md` configures the agent to read its own SKILL.md — no fallback to a generic agent needed.
 
 ---
 
 ## Plan Phase: Re-entry with Guidance Template
 
-When the orchestrator re-enters `sdd-plan` after collecting adviser guidance:
+When the orchestrator re-enters `sdd-plan` after collecting advisor guidance:
 
 Task(
   description: 'plan re-entry (guidance round {N}) for {change-name}',
@@ -142,16 +142,16 @@ Task(
   - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
   GUIDANCE (Round {N}):
-  Adviser recommendations collected by orchestrator. For each entry below, fetch full content via
+  Advisor recommendations collected by orchestrator. For each entry below, fetch full content via
   mem_get_observation(id) if an ID is provided, or read the inline text directly if no ID.
 
-  {for each adviser:}
-  ### {adviser-skill} (engram ID: {observation_id or "inline"})
-  {if inline: paste adviser output directly}
+  {for each advisor:}
+  ### {advisor-skill} (engram ID: {observation_id or "inline"})
+  {if inline: paste advisor output directly}
   {if ID: "Fetch via mem_get_observation({observation_id})"}
 
   TASK:
-  Integrate the adviser recommendations into plan.md.
+  Integrate the advisor recommendations into plan.md.
   For each recommendation:
   1. Assess whether it applies (some may not fit scope)
   2. If it applies: update the relevant task, add/modify Detail Block, adjust Before/After, or add a new task

--- a/workflows/sdd/_shared/envelope-contract.md
+++ b/workflows/sdd/_shared/envelope-contract.md
@@ -14,7 +14,7 @@ Every SDD skill (explore, plan, implement, review) MUST return the SDD Envelope 
 |--------|---------|
 | `ok` | Phase completed successfully |
 | `warning` | Completed, but with concerns that need attention |
-| `guidance_requested` | Plan phase completed; adviser consultation required before finalizing. Orchestrator must launch advisers and re-enter plan with guidance. |
+| `guidance_requested` | Plan phase completed; advisor consultation required before finalizing. Orchestrator must launch advisors and re-enter plan with guidance. |
 | `blocked` | Cannot proceed -- missing input, unresolved dependency, or ambiguity |
 | `failed` | Error during execution |
 
@@ -33,8 +33,8 @@ Copy this block and fill it in as the last output of your skill:
 | **Phase** | explore / plan / implement / review |
 | **Change** | {change-name} |
 | **Engram Ref** | _(optional)_ observation ID from `mem_save`, or omit if engram not used |
-| **Requested Advisers** | _(only when status=guidance_requested)_ comma-separated adviser skill names, e.g. `architect-adviser, api-first-adviser` |
-| **Guidance Context** | _(only when status=guidance_requested)_ 1-3 paragraph summary of what advisers should review: key design decisions, tradeoffs, uncertainties |
+| **Requested Advisors** | _(only when status=guidance_requested)_ comma-separated advisor skill names, e.g. `architect-advisor, api-first-advisor` |
+| **Guidance Context** | _(only when status=guidance_requested)_ 1-3 paragraph summary of what advisors should review: key design decisions, tradeoffs, uncertainties |
 
 ### Executive Summary
 2-4 sentences. What was done, key decisions made, and outcomes. Must be enough for someone to decide whether to proceed without reading the full artifacts.
@@ -53,4 +53,4 @@ Copy this block and fill it in as the last output of your skill:
 
 > **When to include Engram Ref:** Include only if you successfully persisted an artifact to engram during this phase. The orchestrator uses this ID for fast recovery.
 >
-> **When to include Requested Advisers / Guidance Context:** Include only when returning `status: guidance_requested`. The orchestrator reads these fields to launch adviser consultations.
+> **When to include Requested Advisors / Guidance Context:** Include only when returning `status: guidance_requested`. The orchestrator reads these fields to launch advisor consultations.

--- a/workflows/sdd/_shared/launch-templates.copilot.md
+++ b/workflows/sdd/_shared/launch-templates.copilot.md
@@ -103,13 +103,13 @@ ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
 
 ---
 
-## Adviser Invocation
+## Advisor Invocation
 
-When consulting an adviser (architect, unit-test, integration-test, component, api-first, etc.),
-invoke `@{adviser-skill}` with this prompt:
+When consulting an advisor (architect, unit-test, integration-test, component, api-first, etc.),
+invoke `@{advisor-skill}` with this prompt:
 
 ```
-{adviser context — relevant code snippets, current design, specific question or concern}
+{advisor context — relevant code snippets, current design, specific question or concern}
 
 Return your response in this exact format:
 
@@ -126,11 +126,11 @@ Return your response in this exact format:
 {the ID returned by mem_save if you persisted advice to engram; omit this section if engram
 is unavailable}
 
-Do NOT return an SDD envelope — advisers return the structured advice format above, not an
+Do NOT return an SDD envelope — advisors return the structured advice format above, not an
 envelope. Persist advice via mem_save if engram is available.
 ```
 
-> **Copilot note**: Adviser agent files load their own SKILL.md — the orchestrator does not
+> **Copilot note**: Advisor agent files load their own SKILL.md — the orchestrator does not
 > inject the skill. The prompt above provides the question context and return-format contract.
 > Internal references within invocation prompts use `launch-templates.md` (installed name).
 

--- a/workflows/sdd/sdd-implement/SKILL.md
+++ b/workflows/sdd/sdd-implement/SKILL.md
@@ -120,7 +120,7 @@ Go straight to `Edit` when the change is clear. Examples:
     - After each batch completes successfully, mark ALL its tasks as `[X]` in plan.md
 
 **Architecture Planning (optional)**
-If you need a high-level plan, check if an architect adviser skill is installed (e.g., `*-architect-adviser`) and use it as a subagent. File selection is essential before doing so:
+If you need a high-level plan, check if an architect advisor skill is installed (e.g., `*-architect-advisor`) and use it as a subagent. File selection is essential before doing so:
 
 ```text
 Plan: Outline the approach to migrate X → Y given the following files.
@@ -302,7 +302,7 @@ Related SDD workflow skills:
 - [sdd-review](../sdd-review/SKILL.md) — next phase: review changes against the plan
 
 Related specialist skills (for subagent invocation):
-- Any installed adviser skills matching `*-adviser` pattern -- discovered dynamically from the skills directory
+- Any installed advisor skills matching `*-advisor` pattern -- discovered dynamically from the skills directory
 
 Shared contracts:
 - [Persistence Contract](../_shared/persistence-contract.md) — shared persistence rules for SDD skills

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -34,9 +34,9 @@ You are a senior software architect specializing in code design and implementati
       would benefit from specialist review (e.g. "get architect input on this pattern",
       "testing strategy needs review"), update the `## Team Selection` section.
    5. Re-run the Detail Quality Gate on the revised plan
-   6. If Team Selection added new advisers in step 4 → return `status: guidance_requested`
-      (same as step 7 — orchestrator will launch advisers and re-enter with guidance).
-      If no new advisers needed → return `status: ok` envelope.
+   6. If Team Selection added new advisors in step 4 → return `status: guidance_requested`
+      (same as step 7 — orchestrator will launch advisors and re-enter with guidance).
+      If no new advisors needed → return `status: ok` envelope.
 
    The `Bash` tool with `crit comment --plan` is required for replying. `Bash(crit:*)` is included in allowed-tools for this purpose.
 
@@ -60,18 +60,18 @@ You are a senior software architect specializing in code design and implementati
    - Do NOT proceed to step 4 until the interview loop has completed
 
 4. Analyze the requested changes and break them down into clear, actionable steps
-5. Team Selection (record which advisers are needed — do NOT invoke yet)
+5. Team Selection (record which advisors are needed — do NOT invoke yet)
 
    **Specialist Skills for Planning Advice:**
 
-   <!-- ADVISER_TABLE_PLACEHOLDER -->
+   <!-- ADVISOR_TABLE_PLACEHOLDER -->
 
-   If no adviser skills are listed above, skip steps 5 and 7 (Team Selection and Guidance Request) and proceed directly to step 6 (Implementation Plan).
+   If no advisor skills are listed above, skip steps 5 and 7 (Team Selection and Guidance Request) and proceed directly to step 6 (Implementation Plan).
 
    Review the feature requirements and identify which specialist skills are relevant.
    Record selections in `## Team Selection` section with reasoning.
    These selections will be returned in the envelope at step 7 if guidance is needed.
-   Do NOT invoke Task() or Skill() for advisers here — that is handled by the orchestrator.
+   Do NOT invoke Task() or Skill() for advisors here — that is handled by the orchestrator.
 
    **Selection Process:**
    1. Analyze the feature requirements from exploration.md
@@ -136,17 +136,17 @@ You are a senior software architect specializing in code design and implementati
 
 7. Guidance Request
 
-   **Rule: if Team Selection (step 5) selected any advisers → return `guidance_requested`.**
+   **Rule: if Team Selection (step 5) selected any advisors → return `guidance_requested`.**
 
-   This is the ONLY condition. If step 5 identified advisers, you MUST request guidance — do not second-guess the selection. If step 5 selected zero advisers, return `status: ok` directly.
+   This is the ONLY condition. If step 5 identified advisors, you MUST request guidance — do not second-guess the selection. If step 5 selected zero advisors, return `status: ok` directly.
 
    **What to include in the envelope:**
-   - `requested_advisers`: comma-separated list of ALL adviser skill names selected in step 5
-   - `guidance_context`: for EACH requested adviser, 1-2 sentences describing what they should focus on. Be specific — reference task IDs, section names, or design decisions from the plan.
+   - `requested_advisors`: comma-separated list of ALL advisor skill names selected in step 5
+   - `guidance_context`: for EACH requested advisor, 1-2 sentences describing what they should focus on. Be specific — reference task IDs, section names, or design decisions from the plan.
 
    **When NOT to request guidance:**
    - When re-entered with a `GUIDANCE:` block (guidance already collected — skip to step 8)
-   - When step 5 selected zero advisers
+   - When step 5 selected zero advisors
 
 8. Guidance Integration Re-entry (TRIGGERED when `GUIDANCE:` block found in launch prompt)
 
@@ -154,7 +154,7 @@ You are a senior software architect specializing in code design and implementati
 
    1. Detect: check if the launch prompt contains `GUIDANCE (Round N):` block.
    2. Read existing plan.md (do NOT start from scratch — revise only).
-   3. For each adviser entry in GUIDANCE block:
+   3. For each advisor entry in GUIDANCE block:
       a. If entry has `engram ID`: call `mem_get_observation(id)` to fetch full advice.
       b. If entry is inline text: read directly.
       c. Assess each recommendation: relevant to scope? affects task quality?
@@ -279,7 +279,7 @@ After completing the plan and updating the status to "Complete", your **LAST out
 See [envelope contract](../_shared/envelope-contract.md) for format.
 
 **Phase-specific guidance:**
-- **Status**: `ok` — plan completed with all sections filled and interview done; OR `guidance_requested` — plan draft complete but adviser consultation needed (include `requested_advisers` and `guidance_context` fields)
+- **Status**: `ok` — plan completed with all sections filled and interview done; OR `guidance_requested` — plan draft complete but advisor consultation needed (include `requested_advisors` and `guidance_context` fields)
 - **Phase**: `plan`
 - **Change**: use the `{change-name}` from this session
 - **Artifacts**: include the plan file path `.sdd/{change-name}/plan.md`
@@ -330,8 +330,8 @@ See [envelope contract](../_shared/envelope-contract.md) for format.
 - 🚫 **Missing Before/After for modification tasks** — any task that modifies existing code MUST include before/after state in Section 2's Before/After Analysis. The implementer cannot reverse-engineer the current state from a one-line description.
 - 🚫 **Empty Contract Specifications** — when the plan introduces new types, interfaces, or data schemas, the Contract Specifications subsection in Section 2 MUST list them with exact signatures. Omitting this forces the implementer to invent type definitions.
 - 🚫 **Writing entire plan in one operation** — use incremental Edit calls
-- 🚫 **Skipping guidance request** — always request adviser guidance when the plan has cross-layer complexity or architectural uncertainty
-- 🚫 **Not integrating guidance** — when re-entered with a GUIDANCE block, always integrate applicable adviser recommendations into the plan before returning ok
+- 🚫 **Skipping guidance request** — always request advisor guidance when the plan has cross-layer complexity or architectural uncertainty
+- 🚫 **Not integrating guidance** — when re-entered with a GUIDANCE block, always integrate applicable advisor recommendations into the plan before returning ok
 - 🚫 **Proposing implementation code** — plan describes WHAT to build (including type signatures, schemas, and interface contracts) but does NOT include full function implementations. Short code snippets showing signatures and structure are expected; complete method bodies are not
 - 🚫 **Ignoring risks section** — always document potential issues and mitigations
 - 🚫 **Omitting test scope from the plan** — always identify required unit and integration tests, even if test code is written in a later phase
@@ -350,7 +350,7 @@ Related SDD workflow skills:
 - [sdd-review](../sdd-review/SKILL.md) — review changes against the plan
 
 Related specialist skills (for advisor subagent invocation):
-- See the **Specialist Skills for Planning Advice** table in step 5 above for the currently installed adviser skills
+- See the **Specialist Skills for Planning Advice** table in step 5 above for the currently installed advisor skills
 
 Shared contracts:
 - [Persistence Contract](../_shared/persistence-contract.md) — shared persistence rules for SDD skills

--- a/workflows/sdd/sdd-plan/templates/plan_template.md
+++ b/workflows/sdd/sdd-plan/templates/plan_template.md
@@ -63,9 +63,9 @@ This prevents the implementer from having to reverse-engineer the current state.
 ## Team Selection
 
 <!--
-Adviser skills identified during planning. These are NOT invoked by sdd-plan directly.
+Advisor skills identified during planning. These are NOT invoked by sdd-plan directly.
 If guidance is needed, sdd-plan returns a guidance_requested envelope listing these skills.
-The orchestrator then launches each adviser, collects guidance, and re-enters sdd-plan
+The orchestrator then launches each advisor, collects guidance, and re-enters sdd-plan
 with the recommendations. See SKILL.md steps 5, 7, and 8 for the full flow.
 -->
 
@@ -76,13 +76,13 @@ with the recommendations. See SKILL.md steps 5, 7, and 8 for the full flow.
 ## Advice Received
 
 <!--
-Adviser recommendations integrated into the plan. This section is populated during
-Guidance Integration re-entry (step 8) — after the orchestrator collects adviser
+Advisor recommendations integrated into the plan. This section is populated during
+Guidance Integration re-entry (step 8) — after the orchestrator collects advisor
 outputs and re-launches sdd-plan with a GUIDANCE block.
-For each adviser: document what was integrated and what was skipped (with rationale).
+For each advisor: document what was integrated and what was skipped (with rationale).
 -->
 
-_No advice received yet. Advisers will be consulted by the orchestrator if guidance is requested._
+_No advice received yet. Advisors will be consulted by the orchestrator if guidance is requested._
 
 ## 3. Implementation Tasks
 

--- a/workflows/sdd/sdd-review/SKILL.md
+++ b/workflows/sdd/sdd-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-review
-description: 'Use when reviewing code changes before commit, comparing implementation against SDD plan, or doing standalone code review with adviser consultation.'
+description: 'Use when reviewing code changes before commit, comparing implementation against SDD plan, or doing standalone code review with advisor consultation.'
 argument-hint: "[change_name?]"
 disable-model-invocation: false
 allowed-tools: Bash(git:*), Bash(pwd), Bash(find:*), Read, Write, Glob, Grep, AskUserQuestion, Skill
@@ -138,13 +138,13 @@ Use the full content from Step 2 as the plan context for your review. If neither
 
 ### Step 3: Report Findings
 
-**Quick path**: If `git diff --stat` shows ≤50 lines changed across ≤3 files, skip adviser skill consultation and proceed directly to the review report. Document 'Adviser consultation skipped — small change (≤50 lines, ≤3 files)' in the report.
+**Quick path**: If `git diff --stat` shows ≤50 lines changed across ≤3 files, skip advisor skill consultation and proceed directly to the review report. Document 'Advisor consultation skipped — small change (≤50 lines, ≤3 files)' in the report.
 
 Format your review as:
 
 1. **Summary** — What the changes accomplish (1-2 sentences)
 2. **Plan Alignment** — (SDD mode only) Tasks completed vs pending
-3. **Critical Issues** — Must be addressed before commit. If a Critical Issue involves domain logic, architecture patterns, or test coverage gaps, check if relevant adviser skills are installed (e.g., skills matching `*-adviser` pattern) and invoke them via the Skill tool to get a detailed diagnosis before reporting.
+3. **Critical Issues** — Must be addressed before commit. If a Critical Issue involves domain logic, architecture patterns, or test coverage gaps, check if relevant advisor skills are installed (e.g., skills matching `*-advisor` pattern) and invoke them via the Skill tool to get a detailed diagnosis before reporting.
 4. **Minor Improvements** — Nice to have, not blocking
 5. **What's Done Well** — Acknowledge good practices
 6. **Actionable Next Steps** — Specific recommendations
@@ -224,7 +224,7 @@ Your **LAST output MUST be the SDD Envelope**. Nothing may follow the envelope.
 
 ## Gotchas
 
-- **Reporting Critical Issues without specialist diagnosis** — before finalizing any Critical Issue, check for available `*-adviser` skills and invoke the relevant one via the Skill tool. Reporting domain logic or test coverage gaps without adviser input produces vague, unactionable feedback.
+- **Reporting Critical Issues without specialist diagnosis** — before finalizing any Critical Issue, check for available `*-advisor` skills and invoke the relevant one via the Skill tool. Reporting domain logic or test coverage gaps without advisor input produces vague, unactionable feedback.
 - **Re-running git commands when Step 0 already resolved them** — Step 0 stashes git status, diff stat, full diff, and recent log via `git -C <target_path>`. Use those values directly; re-executing git commands wastes turns and may produce stale results if the working tree changes mid-review.
 - **Blocking on minor issues** — distinguish Critical (must fix before commit) from Minor (nice-to-have). Marking minor issues as blockers stalls workflow unnecessarily.
 - **Making code changes during review** — the review phase analyzes only; never modifies files. Any fixes belong in a follow-up implementation task.
@@ -236,7 +236,7 @@ Your **LAST output MUST be the SDD Envelope**. Nothing may follow the envelope.
 - 🚫 **Vague feedback** — provide specific, actionable recommendations
 - 🚫 **Blocking on minor issues** — distinguish critical from nice-to-have
 - 🚫 **Making code changes** — review only analyzes, never modifies
-- 🚫 **Reporting Critical Issues without specialist diagnosis** — if the issue touches domain logic or test patterns, check for available adviser skills (matching `*-adviser` pattern) and invoke the relevant one before finalising the report
+- 🚫 **Reporting Critical Issues without specialist diagnosis** — if the issue touches domain logic or test patterns, check for available advisor skills (matching `*-advisor` pattern) and invoke the relevant one before finalising the report
 - 🚫 **Invoking git:commit or other flow skills directly** — return the envelope; the orchestrator decides what runs next
 - 🚫 **Using legacy .spec references** — all context lives in `.sdd/{change-name}/`
 
@@ -248,7 +248,7 @@ Related SDD workflow skills:
 - [sdd-implement](../sdd-implement/SKILL.md) — implementation phase
 
 Related specialist skills (auto-invoked for Critical Issues):
-- Any installed adviser skills matching `*-adviser` pattern (e.g., `architect-adviser`, `unit-test-adviser`, etc.) -- discovered dynamically from the skills directory
+- Any installed advisor skills matching `*-advisor` pattern (e.g., `architect-advisor`, `unit-test-advisor`, etc.) -- discovered dynamically from the skills directory
 
 Shared contracts:
 - [envelope-contract](../_shared/envelope-contract.md) — standard SDD envelope format

--- a/workflows/sdd/workflow.yaml
+++ b/workflows/sdd/workflow.yaml
@@ -31,9 +31,9 @@ components:
       model: opus
     - name: sdd-orchestrator
       kind: orchestrator
-    - name: sdd-adviser
+    - name: sdd-advisor
       kind: subagent
-      skill: "*-adviser"
+      skill: "*-advisor"
       model: opus
   decisionRules:
     - scenario: '"commit", "commit my changes", "create commit"'
@@ -41,17 +41,17 @@ components:
     - scenario: '"create PR", "pull request", "create pull request"'
       resolution: "Use `git-pull-request`"
     - scenario: '"Review my tests" + integration test files'
-      resolution: "Use `integration-test-adviser`"
+      resolution: "Use `integration-test-advisor`"
     - scenario: '"Review my tests" + domain unit test files'
-      resolution: "Use `unit-test-adviser`"
+      resolution: "Use `unit-test-advisor`"
     - scenario: '"Design an API" + mentions OpenAPI/REST'
-      resolution: "Use `api-first-adviser`"
+      resolution: "Use `api-first-advisor`"
     - scenario: '"Design a service" + mentions architecture/DDD'
-      resolution: "Use `architect-adviser`"
+      resolution: "Use `architect-advisor`"
     - scenario: '"Review my component" + React/TypeScript'
-      resolution: "Use `component-adviser`"
+      resolution: "Use `component-advisor`"
     - scenario: '"Review my tests" + frontend test files'
-      resolution: "Use `frontend-test-adviser`"
+      resolution: "Use `frontend-test-advisor`"
   invocationControls:
     - skills: "git-commit, git-pull-request"
       description: "When user requests commit/PR operations (see Decision Rules)"


### PR DESCRIPTION
## Summary

- Finishes the `adviser → advisor` rename started in #12 / a7f5418, which renamed skill directories but left workflow metadata and prose references unchanged.
- Renames the SDD role `sdd-adviser` → `sdd-advisor` and the sentinel skill pattern `*-adviser` → `*-advisor` in `workflows/sdd/workflow.yaml`.
- Renames `workflows/sdd/_shared/adviser-templates.md` → `advisor-templates.md` and updates all references in the four ORCHESTRATOR variants.
- Replaces `{WORKFLOW_MODEL_ADVISER}` → `{WORKFLOW_MODEL_ADVISOR}` and `<!-- ADVISER_TABLE_PLACEHOLDER -->` → `<!-- ADVISOR_TABLE_PLACEHOLDER -->`; companion DevRune CLI keeps the legacy markers as one-release compat shims.
- Updates residual prose in `sdd-plan/SKILL.md`, `sdd-review/SKILL.md`, `sdd-implement/SKILL.md`, `_shared/envelope-contract.md`, `_shared/launch-templates.copilot.md`, and the `*-advisor` skill files (Adviser Mode headings, engram titles).

## Why

Without this, fresh installs still showed a duplicate **Adviser / Advisor** row in the model selection step and synthesised an `sdd-adviser` sub-agent in `opencode.json`, because DevRune reads the role name straight from `workflow.yaml`.

## Test plan

- [ ] Clear the DevRune package cache (`~/Library/Caches/devrune/packages`).
- [ ] Run `devrune install` against this branch's catalog.
- [ ] Confirm the model-selection step shows a single **Advisor** row (no Adviser).
- [ ] Confirm `.opencode/opencode.json` has `sdd-advisor` (and no `sdd-adviser`) entry.
- [ ] Confirm `.claude/agents/` only contains `*-advisor.md` wrappers.
- [ ] Confirm `REGISTRY.claude.md` is not copied into `.opencode/sdd-orchestrator/` or other non-Claude workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)