### PR TITLE
fix(rules): update applies_to from *-adviser to *-advisor

### DIFF
--- a/rules/api/api-standards-rules.md
+++ b/rules/api/api-standards-rules.md
@@ -2,7 +2,7 @@
 name: api-standards
 scope: api
 applies-to:
-  - api-first-adviser
+  - api-first-advisor
 description: "REST API naming, validation, error models, versioning"
 paths:
   - "**/*.{yaml,yml}"

--- a/rules/architecture/4-rules-of-simple-design-rules.md
+++ b/rules/architecture/4-rules-of-simple-design-rules.md
@@ -2,7 +2,7 @@
 name: 4-rules-of-simple-design
 scope: architecture
 applies-to:
-  - architect-adviser
+  - architect-advisor
 description: "Kent Beck's 4 Rules of Simple Design: test-first, clarity, DRY, minimality"
 paths:
   - "**/*.java"
@@ -116,4 +116,4 @@ When applying these rules during architecture reviews, follow this sequence:
 2. **Apply Rule 2** -- Read the code as a newcomer. Can you understand each module's purpose from its name and structure alone? Flag anything that requires "insider knowledge" to decode.
 3. **Apply Rule 3** -- Search for duplicated knowledge (not just duplicated lines). Check if the same business rule appears in multiple places or if similar abstractions could be unified without losing clarity (respect Rule 2 priority).
 4. **Apply Rule 4** -- Identify elements that do not serve Rules 1-3. Question unused abstractions, empty layers, and speculative patterns.
-5. **Report findings** using the architect-adviser output format: Issues sorted by severity, with each issue referencing the specific rule violated.
+5. **Report findings** using the architect-advisor output format: Issues sorted by severity, with each issue referencing the specific rule violated.

--- a/rules/architecture/clean-architecture-rules.md
+++ b/rules/architecture/clean-architecture-rules.md
@@ -2,7 +2,7 @@
 name: clean-architecture
 scope: architecture
 applies-to:
-  - architect-adviser
+  - architect-advisor
 description: "Hexagonal architecture, DDD patterns, ports and adapters"
 paths:
   - "**/*.java"

--- a/rules/tech/accessibility-standards-rules.md
+++ b/rules/tech/accessibility-standards-rules.md
@@ -2,9 +2,9 @@
 name: a11y
 scope: tech
 applies-to:
-  - web-accessibility-adviser
-  - component-adviser
-  - frontend-test-adviser
+  - web-accessibility-advisor
+  - component-advisor
+  - frontend-test-advisor
 description: 'Web accessibility standards: WCAG 2.2 AA, ARIA patterns, keyboard navigation, semantic HTML.'
 paths:
   - "**/*.{tsx,jsx}"

--- a/rules/tech/frontend-testing-rules.md
+++ b/rules/tech/frontend-testing-rules.md
@@ -2,8 +2,8 @@
 name: frontend-testing
 scope: tech
 applies-to:
-  - frontend-test-adviser
-  - component-adviser
+  - frontend-test-advisor
+  - component-advisor
 description: 'Frontend testing standards: React Testing Library, Vitest/Jest, Cypress/Playwright e2e, test structure, mocking, coverage.'
 paths:
   - "**/*.test.{ts,tsx}"

--- a/rules/tech/java-spring-rules.md
+++ b/rules/tech/java-spring-rules.md
@@ -3,10 +3,10 @@ name: java-spring
 scope: tech
 technology: java
 applies-to:
-  - architect-adviser
-  - unit-test-adviser
-  - integration-test-adviser
-  - api-first-adviser
+  - architect-advisor
+  - unit-test-advisor
+  - integration-test-advisor
+  - api-first-advisor
 description: "Java Spring Boot conventions: module structure, DI, testing, API patterns"
 paths:
   - "**/*.java"

--- a/rules/tech/microfrontends-rules.md
+++ b/rules/tech/microfrontends-rules.md
@@ -2,7 +2,7 @@
 name: microfrontends
 scope: tech
 applies-to:
-  - component-adviser
+  - component-advisor
 description: 'Microfrontend architecture: host/shell mediator pattern, EventBus communication, no MFE versioning, zero breaking changes.'
 paths:
   - "**/*.{tsx,ts}"

--- a/rules/tech/react-rules.md
+++ b/rules/tech/react-rules.md
@@ -2,8 +2,8 @@
 name: react
 scope: tech
 applies-to:
-  - component-adviser
-  - frontend-test-adviser
+  - component-advisor
+  - frontend-test-advisor
 description: 'React and TypeScript coding standards: component patterns, hooks, props, naming, file structure.'
 paths:
   - "**/*.{tsx,jsx}"

--- a/rules/testing/adapter-it-patterns-rules.md
+++ b/rules/testing/adapter-it-patterns-rules.md
@@ -2,7 +2,7 @@
 name: adapter-it-patterns
 scope: testing
 applies-to:
-  - integration-test-adviser
+  - integration-test-advisor
 description: "Adapter integration test patterns with WireMock for HTTP service simulation"
 paths:
   - "**/*IT.java"

--- a/rules/testing/java-unit-tests-rules.md
+++ b/rules/testing/java-unit-tests-rules.md
@@ -2,7 +2,7 @@
 name: java-unit-tests
 scope: testing
 applies-to:
-  - unit-test-adviser
+  - unit-test-advisor
 description: "Java Unit Test Standards"
 paths:
   - "**/*Test.java"

--- a/rules/testing/mother-pattern-rules.md
+++ b/rules/testing/mother-pattern-rules.md
@@ -2,7 +2,7 @@
 name: mother-pattern
 scope: testing
 applies-to:
-  - unit-test-adviser
+  - unit-test-advisor
 description: "Mother builder pattern, test data construction, BDDMockito"
 paths:
   - "**/*Mother.java"


### PR DESCRIPTION
## Summary

- Follow-up to #17. The previous PR completed the `adviser → advisor` rename in workflows and skills, but the rule files under `rules/` still listed `*-adviser` names in their `applies_to:` frontmatter.
- Updates `applies_to` values across 11 rule files (`api/`, `architecture/`, `tech/`, `testing/`) so advisors targeting these rules pick them up after installation.

## Why

After installing with the merged catalog from #17, the rule files materialised into `.claude/rules/` still contained `applies_to: *-adviser`. Since DevRune now installs advisors as `*-advisor`, the rules wouldn't be associated with their advisor skill, and the rule scope-matching wouldn't fire.

## Test plan

- [ ] Clear DevRune cache and reinstall.
- [ ] Confirm `.claude/rules/*.md` and `.agents/rules/*.md` only contain `*-advisor` references in `applies_to:` (no `-adviser`).
- [ ] Confirm an advisor (e.g. `architect-advisor`) loads its associated rules at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)