### PR TITLE
feat(sdd): auto-launch implement after Crit plan approval

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -105,10 +105,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 7. **Ask or auto-continue**:
    - explore `ok` → auto-launch plan (no ask)
    - explore `warning/blocked` → ask user
+   - plan `ok` (post-crit, approved — `crit_completed: true` in state.yaml) → auto-launch implement (no ask — Crit already captured human approval inline)
    - implement `ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
 
-   **Crit confirmation guard**: If `which crit` succeeds after plan `ok`: check `crit_completed` in state.yaml. If absent/false: MUST auto-launch Crit Plan Review (return to step 6). If true: ask user normally.
+   **Crit confirmation guard**: If `which crit` succeeds after plan `ok`: check `crit_completed` in state.yaml. If absent/false: MUST auto-launch Crit Plan Review (return to step 6). If true: auto-launch implement directly (no ask — see plan post-crit rule above). This guard mainly fires on compaction recovery, when step 7 is re-entered after Crit has already approved.
 
 ## Crit Plan Review Protocol
 
@@ -121,7 +122,7 @@ Triggered by Post-Phase step 6 when `which crit` succeeds after a plan phase.
 4. **Parse**: Extract comments where `resolved` is `false` or missing.
 5. **Branch**:
    - **Unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-planner` via `Agent(subagent_type: 'sdd-planner', ...)` with the CRIT_FEEDBACK block in the prompt. After envelope returns, increment `plan_review_round` and loop back to step 1.
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7.
+   - **No unresolved comments**: Plan approved. Set `crit_completed: true` in `.sdd/{change}/state.yaml`. Show "Plan approved via Crit review. Auto-launching implement phase." Proceed to Post-Phase step 7.
 
 **CRIT_FEEDBACK format** (injected into sdd-planner re-entry prompt):
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -100,13 +100,14 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 7. **Ask or auto-continue**:
    - explore `status: ok` → auto-launch plan (no ask — 99% of the time users continue immediately)
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
+   - plan `status: ok` (post-crit, approved — `crit_completed: true` in state.yaml) → auto-launch implement (no ask — the human already approved the plan inline via Crit, asking again is redundant)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → Ask the user: **Continue to {next}** / **Review artifacts** / **Abort**
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
    - Check `crit_completed` in `.sdd/{change}/state.yaml`.
    - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 6).
-   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the ask in step 7.
+   - If `crit_completed` is `true`: crit was executed and approved — auto-launch implement directly (no ask — see plan post-crit rule above). This guard exists for compaction-recovery cases where the orchestrator re-enters step 7 after Crit already approved.
 
 ## Crit Plan Review Protocol
 
@@ -118,7 +119,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 3. **Parse**: Extract all comments where `resolved` is `false` or missing.
 4. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `@sdd-planner` with the plan re-entry prompt (include the CRIT_FEEDBACK block and ask it to revise plan.md). The full re-entry prompt template is in `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round — always foreground).
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7 (Ask the user: **Continue to implement** / **Review artifacts** / **Abort**).
+   - **No unresolved comments**: Plan approved. Set `crit_completed: true` in `.sdd/{change}/state.yaml`. Show "Plan approved via Crit review. Auto-launching implement phase." Proceed to Post-Phase step 7.
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
 

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -94,13 +94,14 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 7. **Ask or auto-continue**:
    - explore `status: ok` → auto-launch plan (no ask — 99% of the time users continue immediately)
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
+   - plan `status: ok` (post-crit, approved — `crit_completed: true` in state.yaml) → auto-launch implement (no ask — the human already approved the plan inline via Crit, asking again is redundant)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
    - Check `crit_completed` in `.sdd/{change}/state.yaml`.
    - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 6).
-   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` in step 7.
+   - If `crit_completed` is `true`: crit was executed and approved — auto-launch implement directly (no ask — see plan post-crit rule above). This guard exists for compaction-recovery cases where the orchestrator re-enters step 7 after Crit already approved.
 
 ## Crit Plan Review Protocol
 
@@ -113,7 +114,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 4. **Parse**: Extract all comments where `resolved` is `false` or missing.
 5. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
+   - **No unresolved comments**: Plan approved. Set `crit_completed: true` in `.sdd/{change}/state.yaml`. Show "Plan approved via Crit review. Auto-launching implement phase." Proceed to Post-Phase step 7.
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -88,13 +88,14 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 7. **Ask or auto-continue**:
    - explore `status: ok` → auto-launch plan (no ask — 99% of the time users continue immediately)
    - explore `status: warning/blocked` → ask user (ambiguities or limitations need resolution first)
+   - plan `status: ok` (post-crit, approved — `crit_completed: true` in state.yaml) → auto-launch implement (no ask — the human already approved the plan inline via Crit, asking again is redundant)
    - implement `status: ok` → auto-launch review (no ask)
    - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** / **Abort**
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with `status: ok`, if `which crit` succeeds:
    - Check `crit_completed` in `.sdd/{change}/state.yaml`.
    - If `crit_completed` is absent or `false`: MUST NOT offer "Continue to implement". Auto-launch Crit Plan Review Protocol immediately (return to step 6).
-   - If `crit_completed` is `true`: crit was executed and approved — proceed normally with the `AskUserQuestion` in step 7.
+   - If `crit_completed` is `true`: crit was executed and approved — auto-launch implement directly (no ask — see plan post-crit rule above). This guard exists for compaction-recovery cases where the orchestrator re-enters step 7 after Crit already approved.
 
 ## Crit Plan Review Protocol
 
@@ -106,7 +107,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 3. **Parse**: Extract all comments where `resolved` is `false` or missing.
 4. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round — always foreground).
-   - **No unresolved comments**: Plan approved. Show "Plan approved via Crit review." Proceed to Post-Phase step 7 (`AskUserQuestion`: **Continue to implement** / **Review artifacts** / **Abort**).
+   - **No unresolved comments**: Plan approved. Set `crit_completed: true` in `.sdd/{change}/state.yaml`. Show "Plan approved via Crit review. Auto-launching implement phase." Proceed to Post-Phase step 7.
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
 

--- a/workflows/sdd/_shared/persistence-contract.md
+++ b/workflows/sdd/_shared/persistence-contract.md
@@ -61,6 +61,11 @@ last_updated: {ISO 8601 datetime}
 plan_review_round: 1  # Optional. Tracks the number of Crit review rounds completed for the plan phase.
                       # Omitted if no Crit review was performed. Incremented by the orchestrator
                       # each time the plan is re-entered with Crit feedback.
+crit_completed: true  # Optional. Set to `true` by the orchestrator when Crit review finishes with no
+                      # unresolved comments (plan approved). Used by the Crit confirmation guard in
+                      # Post-Phase step 7 to (a) skip the redundant "Continue to implement" prompt and
+                      # auto-launch implement, and (b) avoid re-launching Crit on compaction recovery.
+                      # Omitted while a Crit review is still in progress or was never run.
 ```
 
 ### Write Rules


### PR DESCRIPTION
Closes #22

## Summary

After the SDD plan phase completes Crit human review with no unresolved comments, the orchestrator now auto-launches the implement phase instead of asking `Continue to implement / Review artifacts / Abort`. The human already approved the plan inline via Crit, so the extra prompt was redundant friction on every plan→implement transition.

The fallback prompt is preserved for cases where Crit is not available, or when the plan exits with `warning` / `blocked`.

## Changes

Applied uniformly to all four orchestrator variants (covers codex, factory, claude, copilot, opencode):

- **Post-Phase step 7** — new bullet: `plan ok (post-crit, approved)` → auto-launch implement (no ask).
- **Crit confirmation guard** — when `crit_completed: true`, auto-launch implement directly instead of falling through to `AskUserQuestion`. The guard now mainly serves compaction recovery (re-entering step 7 after a restart).
- **Crit Plan Review Protocol** — the "no unresolved comments" branch sets `crit_completed: true` in `state.yaml` and proceeds to step 7. Same shape across all variants; no extra implementation detail (the agent already knows what to do from step 7).
- **`_shared/persistence-contract.md`** — document `crit_completed` in the `state.yaml` schema. Previously read by the guard but never written — latent bug fixed alongside.

## Files

- `workflows/sdd/ORCHESTRATOR.md` (codex + factory)
- `workflows/sdd/ORCHESTRATOR.claude.md`
- `workflows/sdd/ORCHESTRATOR.copilot.md`
- `workflows/sdd/ORCHESTRATOR.opencode.md`
- `workflows/sdd/_shared/persistence-contract.md`

## Test plan

- [ ] Run an SDD workflow on a Claude install with Crit available; confirm implement auto-launches after Crit approval (no Continue/Review/Abort prompt).
- [ ] Run an SDD workflow on an install without Crit (`which crit` fails); confirm the existing Continue/Review/Abort prompt still appears (unchanged behaviour).
- [ ] Force a plan `warning` exit; confirm the prompt still appears (unchanged behaviour).
- [ ] Compaction recovery: with `crit_completed: true` already in `state.yaml`, confirm the orchestrator does not re-launch Crit and goes straight to implement.