### PR TITLE
fix(sdd): anchor artifact paths to {project path}, cite SKILL.md via {SKILLS_PATH}

### DIFF
--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -26,7 +26,7 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 When SDD is triggered:
 1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
-2. Create artifact directory: `mkdir -p .sdd/{change-name}` (use RELATIVE path, not absolute)
+2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
 3. Follow the Orchestrator instructions to launch sub-agents via the `Agent` tool
 
 **Do NOT** use `Task()` or call `Skill("sdd-explore")`, `Skill("sdd-plan")`, etc. directly — sub-agent skills are preloaded via `skills:` frontmatter. Launch sub-agents with `Agent(subagent_type: 'sdd-{phase}', prompt: '<dynamic context only>')`.

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -31,7 +31,7 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 When SDD is triggered:
 1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly _(Codex/Factory only — OpenCode and Copilot: skip the fallback; Skill() is always available)_
 2. Read `{WORKFLOW_DIR}/_shared/launch-templates.md` — copy-paste templates for `Task()` calls
-3. Create artifact directory: `mkdir -p .sdd/{change-name}` (use RELATIVE path, not absolute)
+3. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
 4. Follow the Orchestrator instructions to launch sub-agents via `Task()` tool
 
 **Do NOT** call sub-agent skills (`Skill("sdd-explore")`, `Skill("sdd-plan")`, etc.) directly — those are loaded BY the sub-agents INSIDE a `Task()`. The orchestrator launches `Task()`, the sub-agent loads the Skill.

--- a/workflows/sdd/_shared/launch-templates.claude.md
+++ b/workflows/sdd/_shared/launch-templates.claude.md
@@ -27,14 +27,14 @@ Agent(
   prompt: 'CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/ (already created)
-  - Previous artifacts: {list of .sdd/{change-name}/ files to read}
+  - Artifact directory: {project path}/.sdd/{change-name}/ (already created)
+  - Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
   TASK:
   {specific task description}
 
   PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 
@@ -63,7 +63,7 @@ Agent(
   prompt: 'CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
@@ -85,7 +85,7 @@ Agent(
   If any checkpoint fails: STOP, return envelope with status: failed.
 
   PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
 
   ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
@@ -111,7 +111,7 @@ Agent(
   prompt: 'CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
@@ -138,7 +138,7 @@ Agent(
   each task.
 
   PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
 
   ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
@@ -191,7 +191,7 @@ Agent(
   prompt: 'CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
   CRIT_FEEDBACK (Round {N}):
@@ -205,7 +205,7 @@ Agent(
   Re-run the Detail Quality Gate.
 
   PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 

--- a/workflows/sdd/_shared/launch-templates.copilot.md
+++ b/workflows/sdd/_shared/launch-templates.copilot.md
@@ -26,14 +26,14 @@ Invoke `@sdd-{phase}` with this prompt:
 CONTEXT:
 - Project: {project path}
 - Change: {change-name}
-- Artifact directory: .sdd/{change-name}/ (already created)
-- Previous artifacts: {list of .sdd/{change-name}/ files to read}
+- Artifact directory: {project path}/.sdd/{change-name}/ (already created)
+- Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
 TASK:
 {specific task description for this phase}
 
 PERSISTENCE: See {project path}/.github/instructions/sdd-orchestrator/_shared/persistence-contract.md
-- Primary: always write to .sdd/{change-name}/
+- Primary: always write to {project path}/.sdd/{change-name}/
 - Engram: save summary if available, skip silently if not
 - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 
@@ -59,7 +59,7 @@ Invoke `@sdd-implementer` with this prompt:
 CONTEXT:
 - Project: {project path}
 - Change: {change-name}
-- Artifact directory: .sdd/{change-name}/
+- Artifact directory: {project path}/.sdd/{change-name}/
 - Previous artifacts: exploration.md, plan.md
 
 TASK:
@@ -89,7 +89,7 @@ are the primary communication channel. Mark completed tasks as [X] in plan.md IM
 after each task.
 
 PERSISTENCE: See {project path}/.github/instructions/sdd-orchestrator/_shared/persistence-contract.md
-- Primary: always write to .sdd/{change-name}/
+- Primary: always write to {project path}/.sdd/{change-name}/
 - Engram: save summary if available, skip silently if not
 
 ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
@@ -146,7 +146,7 @@ Invoke `@sdd-planner` with this prompt:
 CONTEXT:
 - Project: {project path}
 - Change: {change-name}
-- Artifact directory: .sdd/{change-name}/
+- Artifact directory: {project path}/.sdd/{change-name}/
 - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
 CRIT_FEEDBACK (Round {N}):
@@ -161,7 +161,7 @@ Re-run the Detail Quality Gate.
 Return the SDD Envelope.
 
 PERSISTENCE: See {project path}/.github/instructions/sdd-orchestrator/_shared/persistence-contract.md
-- Primary: always write to .sdd/{change-name}/
+- Primary: always write to {project path}/.sdd/{change-name}/
 - Engram: save summary if available, skip silently if not
 - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 

--- a/workflows/sdd/_shared/launch-templates.md
+++ b/workflows/sdd/_shared/launch-templates.md
@@ -33,14 +33,14 @@ Task(
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/ (already created)
-  - Previous artifacts: {list of .sdd/{change-name}/ files to read}
+  - Artifact directory: {project path}/.sdd/{change-name}/ (already created)
+  - Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
   TASK:
   {specific task description}
 
   PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 
@@ -67,7 +67,7 @@ Task(
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
@@ -108,7 +108,7 @@ Task(
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
@@ -180,7 +180,7 @@ Task(
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
   CRIT_FEEDBACK (Round {N}):
@@ -194,7 +194,7 @@ Task(
   Return the SDD Envelope.
 
   PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 

--- a/workflows/sdd/_shared/launch-templates.opencode.md
+++ b/workflows/sdd/_shared/launch-templates.opencode.md
@@ -29,19 +29,19 @@ Subagent type mapping per phase:
 Task(
   description: '{phase} for {change-name}',
   subagent_type: '{subagent type from table above}',
-  prompt: 'Your instructions are in {WORKFLOW_DIR}/sdd-{phase}/SKILL.md — read it first, then follow those instructions.
+  prompt: 'Your instructions are in {SKILLS_PATH}/sdd-{phase}/SKILL.md — read it first, then follow those instructions.
 
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/ (already created)
-  - Previous artifacts: {list of .sdd/{change-name}/ files to read}
+  - Artifact directory: {project path}/.sdd/{change-name}/ (already created)
+  - Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
   TASK:
   {specific task description for this phase}
 
   PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
   - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
 
@@ -65,12 +65,12 @@ The implement phase is special: the orchestrator reads plan.md and launches one 
 Task(
   description: 'implement batch {batch-id} for {change-name}',
   subagent_type: '{WORKFLOW_SUBAGENT_IMPLEMENTER}',
-  prompt: 'Your instructions are in {WORKFLOW_DIR}/sdd-implement/SKILL.md — read it first, then follow those instructions.
+  prompt: 'Your instructions are in {SKILLS_PATH}/sdd-implement/SKILL.md — read it first, then follow those instructions.
 
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
@@ -96,7 +96,7 @@ Task(
   or launch additional Task() calls for other batches. The orchestrator owns progression.
 
   PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
 
   QUALITY GATE: After the LAST task of each batch, run the Phase Checkpoint criteria
@@ -133,12 +133,12 @@ When the orchestrator re-enters `sdd-plan` after a Crit review round:
 Task(
   description: 'plan re-entry (crit round {N}) for {change-name}',
   subagent_type: '{WORKFLOW_SUBAGENT_PLANNER}',
-  prompt: 'Your instructions are in {WORKFLOW_DIR}/sdd-plan/SKILL.md — read it first, then follow those instructions.
+  prompt: 'Your instructions are in {SKILLS_PATH}/sdd-plan/SKILL.md — read it first, then follow those instructions.
 
   CONTEXT:
   - Project: {project path}
   - Change: {change-name}
-  - Artifact directory: .sdd/{change-name}/
+  - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
   CRIT_FEEDBACK (Round {N}):
@@ -152,7 +152,7 @@ Task(
   Re-run the Detail Quality Gate.
 
   PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to .sdd/{change-name}/
+  - Primary: always write to {project path}/.sdd/{change-name}/
   - Engram: save summary if available, skip silently if not
 
   ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per


### PR DESCRIPTION
Closes #29 · companion to davidarce/DevRune#56

## Summary

Two related path bugs in the SDD workflow templates, surgical fix in the templates only — no new abstractions, no new placeholders, no bash snippets in instructions.

## Bug 1 — `.sdd/{change}/` ends up in a nested repo

Workspaces with multiple nested git repos surfaced this: artifacts landed at `<workspace>/<nested-repo>/.sdd/{change}/` instead of `<workspace>/.sdd/{change}/`.

**Root cause**: `REGISTRY.md` step 3 explicitly told the orchestrator "use RELATIVE path, not absolute". Every launch template then repeated the relative form for `Artifact directory:`, `Primary: always write to ...`, and `Previous artifacts:`. A sub-agent running with cwd in a nested repo resolved `.sdd/...` against the wrong root.

**Fix**: anchor every artifact reference to `{project path}/.sdd/{change-name}/`. `{project path}` is already the absolute project path the orchestrator injects into each prompt — no new placeholder, no renderer change.

## Bug 2 — OpenCode launch prompts cite a non-existent SKILL.md path

The OpenCode template wrote `{WORKFLOW_DIR}/sdd-{phase}/SKILL.md`. DevRune's OpenCode renderer (`internal/materialize/renderers/opencode.go:390`) resolves `{WORKFLOW_DIR}` to `<workspace>/sdd-orchestrator/`, so the cited path becomes `<workspace>/sdd-orchestrator/sdd-{phase}/SKILL.md` — a directory that doesn't exist. SKILL.md actually lives under `{SKILLS_PATH}` (e.g. `<workspace>/.agents/skills/sdd-{phase}/SKILL.md` or `<workspace>/.opencode/skills/...`).

**Fix**: change all three OpenCode SKILL.md citations to `{SKILLS_PATH}/sdd-{phase}/SKILL.md`. Claude (auto-loads via frontmatter) and Copilot (inlines SKILL.md body) don't cite paths at all, so they're unaffected. The base/codex/factory template (`launch-templates.md`) already used `{SKILLS_PATH}` — only OpenCode was wrong.

## Files

- `workflows/sdd/REGISTRY.md`, `REGISTRY.claude.md` — replace "use RELATIVE path, not absolute" with `{project path}/.sdd/{change-name}/`.
- `workflows/sdd/_shared/launch-templates.md`, `.claude.md`, `.copilot.md`, `.opencode.md` — `Artifact directory:`, `Primary: always write to ...`, `Previous artifacts:` all use `{project path}/.sdd/{change-name}/`.
- `workflows/sdd/_shared/launch-templates.opencode.md` — three `{WORKFLOW_DIR}/sdd-{phase}/SKILL.md` → `{SKILLS_PATH}/sdd-{phase}/SKILL.md`.

6 files, +35/−35.

## Test plan

- [ ] `devrune install` for an OpenCode workspace; trigger SDD; verify the implementer launch prompt cites a SKILL.md path that exists on disk.
- [ ] In a workspace containing a nested repo, trigger SDD from the workspace root; verify `.sdd/{change}/` is created at the workspace root, not inside the nested repo.
- [ ] Same workspace, but invoke from inside the nested repo: verify the orchestrator captures the nested repo as `{project path}` (intentional — the orchestrator's invocation cwd is the anchor) and creates `.sdd/{change}/` there. If the user wants the workspace root instead, they invoke from there.
- [ ] Sanity-check the other agents (Claude, Codex/Factory, Copilot) — no behaviour change for them, since their templates either don't cite SKILL.md (Claude, Copilot) or already used `{SKILLS_PATH}` (base).