### PR TITLE
feat(sdd): hard role invariant + post-compaction re-assertion (M1+M2)

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -1,5 +1,13 @@
 # SDD Orchestrator (Claude-native, delegate-only coordinator)
 
+## Role Invariant — you orchestrate, you do not implement
+
+Outside `.sdd/{change}/`, your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
+
 ```
                         SDD Phase Pipeline
   ┌──────────┐    ┌──────────┐    ┌──────────────┐    ┌──────────┐

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -1,5 +1,13 @@
 # SDD Orchestrator (delegate-only coordinator)
 
+## Role Invariant — you orchestrate, you do not implement
+
+Outside `.sdd/{change}/`, your only outputs are: sub-agent invocations via `@sdd-{phase}` (natural-language @-mention), questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, load `sdd-{phase}` skills inline.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
+
 ```
                         SDD Phase Pipeline
   ┌──────────┐    ┌──────────┐    ┌──────────────┐    ┌──────────┐

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -1,6 +1,14 @@
 # SDD Orchestrator (delegate-only coordinator)
 <!-- Also invocable as Skill("sdd-orchestrator") — see SKILL.md for entry point -->
 
+## Role Invariant — you orchestrate, you do not implement
+
+Outside `.sdd/{change}/`, your only outputs are: sub-agent launches (`Task` / `Agent` / `@<sub-agent>` per your variant), `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
+
 ```
                         SDD Phase Pipeline
   ┌──────────┐    ┌──────────┐    ┌──────────────┐    ┌──────────┐

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -1,5 +1,13 @@
 # SDD Orchestrator (delegate-only coordinator)
 
+## Role Invariant — you orchestrate, you do not implement
+
+Outside `.sdd/{change}/`, your only outputs are: sub-agent launches via `Task(subagent_type: '...', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
+
 ```
                         SDD Phase Pipeline
   ┌──────────┐    ┌──────────┐    ┌──────────────┐    ┌──────────┐

--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -1,3 +1,11 @@
+## SDD Role Invariant — you orchestrate, you do not implement
+
+When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
+
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
 ## SDD — Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -2,6 +2,14 @@
 >
 > **Codex and Factory agents**: All instructions below apply in full.
 
+## SDD Role Invariant — you orchestrate, you do not implement
+
+When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches (`Task` / `Agent` / `@<sub-agent>` per your variant), `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
+
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
 ## SDD — Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)

--- a/workflows/sdd/_shared/recovery.md
+++ b/workflows/sdd/_shared/recovery.md
@@ -2,7 +2,15 @@
 
 ## Compaction Recovery Protocol
 
-You arrived here because the catalog's Compaction Recovery directive detected an active SDD workflow. You are the SDD orchestrator -- a delegate-only coordinator.
+You arrived here because the catalog's Compaction Recovery directive detected an active SDD workflow.
+
+### Role Invariant (re-assert NOW, before recovery steps)
+
+You are the SDD orchestrator. **You orchestrate, you do not implement.** Outside `.sdd/{change}/`, your only outputs are: sub-agent launches (`Task` / `Agent` / `@<sub-agent>` per your variant), `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read ORCHESTRATOR.md and delegate.
 
 ### Recovery Steps
 

--- a/workflows/sdd/hooks/sdd-session-compact.sh
+++ b/workflows/sdd/hooks/sdd-session-compact.sh
@@ -8,8 +8,22 @@ find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read 
   next_step="$(grep '^next_step:' "$state_file" | sed 's/next_step: *//')"
   [ -z "$current_phase" ] && current_phase="unknown"
   [ -z "$next_step" ] && next_step="check state.yaml for details"
-  echo "CRITICAL: SDD workflow was active during compaction. You MUST run compaction recovery NOW."
-  echo "Read ${state_file} and check engram for active-workflow marker."
-  echo "Load Skill(sdd-orchestrator) and resume from the NEXT directive in the marker."
-  echo "Current phase: ${current_phase}. NEXT: ${next_step}."
+
+  cat <<EOF
+CRITICAL: SDD workflow "${change_name}" was active during compaction. You MUST run compaction recovery NOW.
+
+## Role Invariant — you orchestrate, you do not implement
+
+Outside .sdd/{change}/, your only outputs are: sub-agent launches (Task / Agent / @<sub-agent>), AskUserQuestion, mkdir for .sdd/, and Bash(crit ...) per the Crit Plan Review Protocol.
+
+You do NOT: Edit/Write source files, run builds/tests/lints, run git commit/push, create branches/commits/PRs, invoke Skill("sdd-{phase}") directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read ORCHESTRATOR.md and delegate.
+
+## Recovery
+
+State: ${state_file} (current_phase: ${current_phase}, NEXT: ${next_step}).
+Check engram for the active-workflow marker (mem_context).
+Load Skill(sdd-orchestrator) and resume from the NEXT directive.
+EOF
 done

--- a/workflows/sdd/plugins/sdd-compaction.ts
+++ b/workflows/sdd/plugins/sdd-compaction.ts
@@ -23,6 +23,17 @@ export const SddCompaction: Plugin = async (_ctx) => {
         const nextStep = nextMatch?.[1] ?? "check state.yaml";
         output.context.push(`## SDD Workflow Recovery (CRITICAL)
 ACTIVE SDD workflow: ${c.name}
+
+## Role Invariant — you orchestrate, you do not implement
+
+Outside .sdd/{change}/, your only outputs are: sub-agent launches via Task(...), AskUserQuestion, mkdir for .sdd/, and Bash(crit ...) per the Crit Plan Review Protocol.
+
+You do NOT: Edit/Write source files, run builds/tests/lints, run git commit/push, create branches/commits/PRs, invoke Skill("sdd-{phase}") directly.
+
+If your next planned action is on the "do not" list, you have lost the role — re-read ORCHESTRATOR.opencode.md and delegate.
+
+## Recovery
+
 Current phase: ${currentPhase}
 NEXT: ${nextStep}
 


### PR DESCRIPTION
First PR from the audit umbrella in #33. Closes M1 (hard role contract) + M2 (re-assert role in compaction hooks). Covers the P0 finding: after compaction, the orchestrator was losing its "delegate-only" role and starting to edit code directly.

Companion regression test in DevRune: davidarce/DevRune#58 (will land after this).

## What

Triple-defense the "delegate-only" contract so it survives compaction and stays prominent:

1. **Top of every `ORCHESTRATOR.md` variant** (base / claude / copilot / opencode) — a `## Role Invariant — you orchestrate, you do not implement` section above the pipeline diagram. The block names what the orchestrator does (sub-agent launches, `AskUserQuestion`, `mkdir` for `.sdd/`, `Bash(crit ...)`) and what it explicitly does **not** (`Edit`/`Write` source files, build/test/lint, `git commit`/`push`, `Skill("sdd-{phase}")`). Trip-wire: *"if your next planned action is on the 'do not' list, you have lost the role — re-read this section and delegate."*
2. **`REGISTRY.md` + `REGISTRY.claude.md`** — same block. These render into the agent's ambient rules / catalog file (`CLAUDE.md`, `AGENTS.md`, etc.), so the contract is present even when the `sdd-orchestrator` skill is not currently loaded — which is exactly the post-compaction scenario.
3. **`_shared/recovery.md`** — the existing buried *"You are the SDD orchestrator — a delegate-only coordinator"* sentence is promoted to the canonical block, placed BEFORE the recovery steps so the orchestrator re-reads the contract before resuming.
4. **`hooks/sdd-session-compact.sh`** (Claude) — instead of emitting 4 generic lines (*"CRITICAL ... Load Skill(sdd-orchestrator)"*), now emits the full Role Invariant block as part of recovered context, followed by the recovery steps.
5. **`plugins/sdd-compaction.ts`** (OpenCode) — same: pushes the Role Invariant block into recovered context via `output.context.push(...)`, then the recovery steps.

## Why per-variant invocation wording

Each ORCHESTRATOR variant names the invocation mechanism in its block:

| Variant | Invocation mechanism in the block |
|---|---|
| base (codex / factory) | `Task` / `Agent` / `@<sub-agent>` (generic) |
| `.claude.md` | `Agent(subagent_type: 'sdd-{phase}', ...)` |
| `.copilot.md` | `@sdd-{phase}` |
| `.opencode.md` | `Task(subagent_type: '...', ...)` |

This avoids the agent looking at a wrong-mechanism reference and dismissing the block as "not for me".

## Files

- `workflows/sdd/ORCHESTRATOR.md`
- `workflows/sdd/ORCHESTRATOR.claude.md`
- `workflows/sdd/ORCHESTRATOR.copilot.md`
- `workflows/sdd/ORCHESTRATOR.opencode.md`
- `workflows/sdd/REGISTRY.md`
- `workflows/sdd/REGISTRY.claude.md`
- `workflows/sdd/_shared/recovery.md`
- `workflows/sdd/hooks/sdd-session-compact.sh`
- `workflows/sdd/plugins/sdd-compaction.ts`

9 files, +86/−5. Shell script syntax verified with `sh -n`.

## Test plan

- [ ] Run an SDD workflow long enough to trigger compaction. After compaction, confirm the recovered context includes the Role Invariant block (via the hook on Claude or the plugin on OpenCode), not just the old generic "Load Skill" message.
- [ ] Inspect the rendered `CLAUDE.md` / `AGENTS.md` / `copilot-instructions.md` after `devrune sync` and verify the Role Invariant block is present in the SDD section.
- [ ] On a fresh SDD invocation, verify the orchestrator's first lines in its prompt include the Role Invariant block.
- [ ] DevRune-side regression test (#58) lands separately and locks the invariant in place across renderers.

## Out of scope (other M-tasks from #33)

- M3 (consolidate Engram persistence) — separate PR
- M4 (collapse Self-Check sections) — separate PR
- M5 (move operational contract out of launch-templates) — separate PR
- M6 (drop role preambles from phase SKILL.md) — separate PR
- M7 (move legacy content to references/) — separate PR
- M8 (drop double `!`-mkdir) — separate PR