### PR TITLE
refactor(sdd): slim phase SKILL.md files (M3+M4+M6)

### DIFF
--- a/workflows/sdd/_shared/persistence-contract.md
+++ b/workflows/sdd/_shared/persistence-contract.md
@@ -209,6 +209,31 @@ to engram before returning:
 Do NOT return without saving what you learned.
 ```
 
+## Phase Artifact Save Convention
+
+When a phase completes, save a structured summary to engram (subject to the Engram Availability Guard). Per-phase parameters:
+
+| Phase | `title` / `topic_key`                  | Content summary                                                       |
+|-------|-----------------------------------------|------------------------------------------------------------------------|
+| explore   | `sdd/{change}/explore`              | Objective, Architecture, Selected Files (paths + one-liner), Relationships, Ambiguities |
+| plan      | `sdd/{change}/plan`                 | Full plan.md content (small enough to fit; otherwise summarize sections) |
+| implement | `sdd/{change}/implement-progress`   | Completed tasks (the `[X]` list), final status (ok/failed), files modified |
+| review    | `sdd/{change}/review-report`        | Summary, Plan Alignment, Critical Issues, Minor Improvements, final status |
+
+Common arguments:
+
+```
+mem_save(
+  title: "<from table>",
+  topic_key: "<same as title>",
+  type: "architecture",
+  project: "{project}",
+  content: "<phase-specific summary>"
+)
+```
+
+Note the returned observation ID and include it as `engram_ref` in the SDD envelope. If engram is unavailable, skip silently — do not error.
+
 ## General Knowledge Persistence Mandate
 
 Sub-agents MUST save significant discoveries to engram before returning, independent of the phase artifact save. This applies to:

--- a/workflows/sdd/sdd-explore/SKILL.md
+++ b/workflows/sdd/sdd-explore/SKILL.md
@@ -6,272 +6,122 @@ disable-model-invocation: false
 allowed-tools: Bash, Bash(tree:*), Read, Glob, Grep, Write, Edit, AskUserQuestion, Skill, mcp__atlassian__jira_get_issue
 ---
 
-<meta prompt 1 = "System: Agent Discover">
-You are the **Discover** agent. Your mission: **curate the perfect file selection** and **craft a precise prompt** for the next model. Do not implement—focus entirely on context discovery and handoff.
+Curate the perfect file selection and craft a precise handoff prompt for the planning phase. Do **not** implement or edit code outside `.sdd/{change-name}/`. The next phase (sdd-plan) sees only what you write to `exploration.md` — when in doubt, include rather than exclude.
 
-**CRITICAL: The Selection Is The Universe**
-The files you select become the next model's entire world. The next model likely will NOT have tool access—they only see what you curate. When in doubt, include rather than exclude—better to have too much context than leave the model blind to critical dependencies.
+Token budget for the final selection: target **50–80k tokens** across files + prompt text; exceed when completeness demands.
 
-Do **not** perform implementation or code edits.
+## Discovery Workflow
 
-**Core Principles**
-- **The next model is isolated:** They see only what you select in the context session file, nothing more
-- **Don't assume a solution:** Select context that enables different approaches, not just your imagined solution
-- **Think like a different model:** Include complete context around the problem area, not just what you think needs changing
-- **Implementation over signatures:** Prefer full files; codemaps lack implementation details
-- **Resolve ambiguity now:** Clarify task scope and context during exploration
-- **Multi-root awareness:** Check roots first, prefix all paths correctly
-- **Token budget includes files + prompt text:** Target **50–80k tokens** for the final selection; exceed if necessary to ensure completeness
+> **Incremental writing**: never accumulate all findings and write `exploration.md` in one giant `Write` at the end — that exceeds output token limits and loops the agent. Initialise the file with the template, then append/update sections via `Edit` after every 3–5 files discovered.
 
-**The Discovery Workflow (Execute In Order)**
+1. **Create the session file** with the template
+   - Path: `.sdd/{change-name}/exploration.md`
+   - Template: [templates/exploration_template.md](templates/exploration_template.md) (do not omit any section)
+   - Use `Write` once to seed the file with placeholders. Fill `## Objective` immediately if the task is clear from the prompt.
 
-**CRITICAL — Incremental Writing Strategy:**
-NEVER accumulate all findings to write exploration.md in one giant Write call at the end. This causes output token limits to be exceeded and the agent loops forever. Instead:
-- Step 1: Create the file with the template (Write)
-- Steps 2-5: After each discovery batch (every 3-5 files read), **immediately update exploration.md using `Edit`** to fill in sections incrementally
-- Step 6: Final pass to polish remaining sections (Edit)
-  This ensures progress is saved continuously and no single tool call needs to generate the entire document.
+2. **Get Jira ticket details** (only when a ticket ID was provided)
+   - Tool: `mcp__atlassian__jira_get_issue` with `{"issue_key": "<ticket_id>"}`
+   - Immediately after: `Edit` `## Objective` and `### Task:` in `exploration.md` with what you learned.
+   - Skip this step entirely if no ticket ID was provided.
 
-1) **Create the session file** — Initialize with the template
-   - Template: Use the exploration template from [templates/exploration_template.md](templates/exploration_template.md) as base, do not omit any section
-   - Format file name: `.sdd/{change-name}/exploration.md`
-   - Use: `Write` tool to create the file with the template placeholders
-   - Also fill in `## Objective` immediately if the task is clear from the prompt
-
-2) **Get Jira ticket details**
-   - **If no ticket ID was provided in the arguments, skip this step entirely and proceed to Step 3.**
-   - Tool: `mcp__atlassian__jira_get_issue`
-   - Args: `{"issue_key": "<ticket_id from arguments>"}`
-   - Purpose: Understand requirements, acceptance criteria
-   - **Immediately after**: Use `Edit` to update `## Objective` and `### Task:` sections in exploration.md with what you learned
-
-3) **START with embedded tree for overview**
-   START by reviewing the embedded tree, then fetch full overview or drill deeper:
+3. **Get the codebase overview**
 
     ```bash
     tree --gitignore -L 6
     ```
 
    Drill into specific directories as needed:
+
     ```bash
     tree --gitignore -L 3 path/to/subdirectory
     ```
 
-4) **Explore the codebase** — Identify relevant files and understand the task
-   - `Glob` — find files by patterns
+   Do **not** add pipes/redirects/`head`/`tail` — `tree --gitignore -L 6` is sufficient and free of permission prompts. Use `Glob`/`Grep` for filtering, never `ls | grep` or `find`.
+
+4. **Explore the codebase** — identify relevant files and understand the task
+   - `Glob` — find files by pattern
    - `Grep` — search for keywords, types, functions where user terms appear
    - `Read` — implementation details for specific sections
    - `tree` — drill into specific directories
-   - **After every 3-5 files read**: Use `Edit` to append findings to `### Selected Context:` and `### Architecture:` sections in exploration.md. Do NOT wait until the end.
+   - After every 3–5 files read: `Edit` `### Selected Context:` and `### Architecture:` in `exploration.md`. Do not defer.
 
-5) **Build selection iteratively**
-   - **Actively add ALL task-relevant files** as full files or directories
-   - Repeat until you maximize implementation context
-   - Use `Edit` to update `### Selected Code Structure` section after each batch of files discovered
-   - Use `Edit` to update `### Selected Files Tree` section after each batch
+5. **Build selection iteratively**
+   - Add ALL task-relevant files as full files or directories.
+   - Update `### Selected Code Structure` and `### Selected Files Tree` after each batch via `Edit`.
+   - **Mode priority**: full files > slices > codemaps. Prefer full files when they fit; use slices for large files; use codemaps for architectural awareness only when budget-constrained. The next model cannot ask for more — when in doubt, include the full file. See [References: file slicing](#references-file-slicing) at the bottom for slice quality rules.
 
-6) **Craft and set the handoff prompt (MANDATORY)** — distill discovery into actionable clarity
+6. **Craft the handoff prompt** (MANDATORY)
 
-   **CRITICAL:** Skipping this step means the next model receives no context about what was discovered.
+   The next model's entire world is what you curate. Skipping or vague handoff text forces the planner to re-derive context that exploration already resolved. Use `Edit` to update each remaining section individually — do **not** rewrite the entire file.
 
-   Emphasize symbols, architecture, and relationships. Be specific and concise.
-
-   Use `Edit` to update each remaining section in exploration.md individually. **Do NOT rewrite the entire file** — only edit sections that still have placeholder text.
-
-   Sections to finalize (use one `Edit` per section):
+   Sections to finalise (one `Edit` per section):
    - `### Relationships:` — call chains and data flow
    - `### Ambiguities:` — open questions or "None"
 
-   **Handoff Contract** — sdd-plan reads exploration.md expecting these exact headings. Use them verbatim:
+   **Handoff Contract** — sdd-plan reads `exploration.md` expecting these exact headings, verbatim:
+
    - `## Objective` — what the feature must achieve
-   - `## User Requirements` — contains the sub-sections below
-      - `### Task:` — clear restatement of what needs to be done
-      - `### Architecture:` — key modules and responsibilities
-      - `### Selected Context:` — file paths with one-line descriptions
-      - `### Relationships:` — call chains and data flow
-      - `### Ambiguities:` — open questions or "None"
+   - `## User Requirements`
+     - `### Task:` — clear restatement of what needs to be done
+     - `### Architecture:` — key modules and responsibilities
+     - `### Selected Context:` — file paths with one-line descriptions
+     - `### Relationships:` — call chains and data flow
+     - `### Ambiguities:` — open questions or "None"
    - `## Selected Code Structure` — flat list of selected file paths
    - `## Selected Files Tree` — directory tree of selected files
 
-## Engram Persistence (Optional — Complementary to .sdd/ Files)
+7. **Verify** — read `exploration.md` once, confirm no `[PENDING]` placeholders remain. Fill any gaps via `Edit`.
 
-After writing exploration.md, persist a **structured summary** to engram if available.
+## Persistence
 
-**Availability guard**: If engram tools are available (`mem_save` exists as a callable tool), execute the save below. If engram tools are NOT available, skip silently — do NOT error, do NOT warn the user, do NOT let engram unavailability block the workflow.
+Save the exploration artifact and any general-knowledge discoveries per `_shared/persistence-contract.md` (Phase Artifact Save Convention + General Knowledge Persistence Mandate). For this phase, `title`/`topic_key` is `sdd/{change}/explore`.
 
-Save the structured summary:
+> Do NOT persist the full `exploration.md` (can be 50–80k tokens). Persist only the structured summary: Objective, Architecture, Selected Files (paths + one-liner), Relationships, Ambiguities — typically 2–5k tokens.
 
-```
-mem_save(
-  title: "sdd/{change-name}/explore",
-  topic_key: "sdd/{change-name}/explore",
-  type: "architecture",
-  project: "{project-name from context}",
-  content: "# Exploration Summary: {change-name}\n\n## Objective\n{copy from exploration.md}\n\n## Architecture\n{copy architecture section}\n\n## Selected Files\n{list file paths with one-line descriptions}\n\n## Relationships\n{copy relationships section}\n\n## Ambiguities\n{copy ambiguities section}"
-)
-```
+## Return Envelope
 
-**IMPORTANT**: Do NOT persist the full exploration.md (can be 50-80k tokens). Persist only the structured summary (~2-5k tokens).
+Return the SDD Envelope as your **last** output (format: `_shared/envelope-contract.md`). Nothing may follow it.
 
-If engram tools are NOT available, skip this step silently. The `.sdd/` files are always the primary source of truth.
+| Field            | Value                                                                                                                                |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Status           | `ok` (successful exploration) · `warning` (ambiguities remain unresolved) · `blocked` (critical context is missing)                  |
+| Phase            | `explore`                                                                                                                            |
+| Artifacts        | `.sdd/{change-name}/exploration.md`                                                                                                  |
+| Next Recommended | `/sdd-plan {change-name}`                                                                                                            |
+| Risks            | Architectural concerns, missing test coverage, unclear requirements; or "None"                                                       |
+| Engram Ref       | Observation ID from the persistence step, or omit if engram unavailable                                                              |
 
-Note the observation ID returned by `mem_save` — include it as `engram_ref` in your envelope if available.
+Do **not** invoke `sdd-plan` (or any other SDD skill) yourself — return the envelope; the orchestrator handles phase transitions.
 
-## General Knowledge Persistence (Optional — When Engram Available)
+## Self-Check (before returning the envelope)
 
-Beyond the SDD phase artifact above, if you discovered important knowledge during exploration that would benefit future sessions, save it to engram:
+- `exploration.md` was written **incrementally** via `Edit` after each batch of files — not in one large `Write` at the end.
+- Selection was **executed** (not just planned), targeting 50–80k tokens; over budget is acceptable when completeness demands it.
+- Any file that might be edited is included with full implementation, not codemap-only.
+- Handoff prompt explains what's included and why; no proposed solutions or implementation approaches in `exploration.md`.
+- Selection covers context for **different approaches**, not only your imagined solution — the next model may solve it differently.
+- Jira ticket fetched (Step 2) when a ticket ID was provided.
+- Did not invoke any other SDD skill, did not edit code outside `.sdd/{change-name}/`.
 
-- Architectural decisions or patterns discovered
-- Non-obvious codebase conventions or gotchas
-- Dependencies or relationships that aren't documented
+## References: file slicing
 
-For each discovery:
+Use slices only when budget-constrained; otherwise prefer full files. Each slice MUST include:
 
-```
-mem_save(
-  title: "{short searchable description}",
-  type: "{decision|discovery|pattern|architecture}",
-  project: "{project-name}",
-  content: "**What**: {description}\n**Why**: {reasoning}\n**Where**: {files affected}\n**Learned**: {gotchas or edge cases}"
-)
-```
+- A descriptive `description` explaining what it contains, why it's relevant, and how it relates to other code (e.g. *"UserAuth.login() and logout() — session management called by LoginView, creates Token objects"*).
+- Imports / type declarations / helper methods needed for the slice to read self-sufficiently.
+- Natural boundaries (class/function blocks, not arbitrary lines).
+- ≥100–200 lines per slice when possible — micro-fragments lose context.
 
-If engram tools are NOT available, skip silently. This is complementary to the .sdd/ artifacts.
-
-7) **Pre-halt checklist (MANDATORY):**
-   - ✅ Files that might be edited: included with implementation (full files or slices)
-   - ✅ Supporting/reference files: included as appropriate (full files, slices)
-   - ✅ Handoff prompt explains what's included and why
-
-8) **Verify exploration.md is complete** — Read the file one final time. Confirm no empty sections and no placeholder text remaining. If any section is incomplete, use `Edit` to fill it in.
-
----
-
-## Gotchas
-
-- **Accumulating all findings to write exploration.md in one giant Write at the end** — this exceeds output token limits and causes infinite loops. Use incremental `Edit` calls after every 3-5 files discovered; never defer all writes to the end.
-- **Skipping Step 2 (Jira fetch) when a ticket ID IS provided** — always retrieve ticket details before exploring. Skipping loses valuable business context (acceptance criteria, scope constraints) that the handoff prompt needs.
-- **Writing implementation proposals into exploration.md** — this file is context only; the plan phase decides approach. Including proposed solutions biases the planning model and narrows its solution space.
-- **Leaving the handoff prompt empty or vague** — the next model's entire world is what you curate. A missing or generic handoff prompt forces the planning model to re-derive context that exploration already resolved.
-- **Narrow file selection based on your assumed solution** — include complete context for different approaches. The planning model may solve it differently; files omitted here are invisible to it.
-- **Adding pipes, redirects, or head/tail to tree commands** — `tree --gitignore -L 6` is all you need. Adding `2>/dev/null`, `| head`, or `| grep` triggers permission prompts because the shell sees output redirection. Use Glob/Grep tools for filtering instead.
-- **Using Bash for file discovery instead of Glob/Grep** — never use `ls | grep` or `find`. Use `Glob` to find files by pattern and `Grep` to search content. Bash is only for `tree` commands.
-- **Reading SKILL.md files from other SDD phases** — you only need YOUR skill instructions (sdd-explore). Do not read sdd-plan, sdd-implement, sdd-review, or launch-templates.md. This wastes context tokens.
-- **Invoking sdd-plan or any other SDD phase after returning your envelope** — your job ends with the envelope. The orchestrator handles phase transitions, Post-Phase Protocol, and Crit detection. Executing the next phase yourself bypasses all of this.
-
----
-
-## Reference: Selection Refinement Process
-
-1. **Initial selection**: Add all relevant files/directories as full files
-   **Priority**: Full files > Slices > Codemaps. Prefer full files when they fit the budget; use slices for large files; use codemaps for architectural context when budget-constrained.
-
-## Reference: Mode Selection Guide
-- **Full files**: Any file that might be edited OR whose implementation is needed
-- **Slices**: Large files where you need specific sections but full file exceeds budget (MUST include descriptive descriptions)
-- **Codemaps**: Reference files where only signatures matter (types, interfaces, dependencies). Useful for architectural awareness without token cost of full implementation.
-
-**In final selection:** Be more conservative—prefer full files
-
-**Critical:** The next model cannot request more information. Missing implementation details causes task failures. When in doubt between modes, prefer more context (full file) over less (codemap).
-
-## Reference: File Slices
-
-When budget-constrained, use slices to include targeted sections instead of full files:
-
-**Before slicing:**
-1. Read relevant sections with `Read` to identify boundaries
-2. Verify relevance — confirm sections directly relate to the task
-3. Check completeness — ensure slices include necessary context (imports, types, called methods)
-4. Pick natural boundaries (class/function blocks, not arbitrary lines)
-5. Write descriptive descriptions explaining what, why, and relationships
-
-**What to include in slices:**
-- The target function/class the task mentions (e.g., UserAuth.login at lines 45-89)
-- Types it returns or depends on (e.g., Token class at lines 120-180)
-- Import statements (lines 1-15) so type references are clear
-- Helper methods it delegates to (lines 200-250)
-
-**What to exclude from slices:**
-- Unrelated functionality (admin functions at lines 300-450)
-- Test fixtures/mocks not needed for understanding
-- Deprecated code marked for removal
-
-**Quality requirements:**
-- **Prefer 100-200+ line self-contained sections** over tiny fragments
-- **REQUIRED: Every slice needs a descriptive `description`** explaining what it contains, why it's relevant, and how it relates to other code
-   - Bad: "UserAuth methods"
-   - Good: "UserAuth.login() and logout() - session management called by LoginView, creates Token objects"
-- Include interconnections (if slicing a function call, include both caller and callee)
-- The consumer sees ONLY your slices—omitting critical context causes task failure
-- Preview slices first to inspect before including them
-
----
-
-## Return Envelope (MANDATORY)
-
-See [envelope contract](../_shared/envelope-contract.md) for format.
-
-After completing all exploration steps, your **LAST output** MUST be the SDD Envelope. Nothing may follow it.
-
-**Rules:**
-1. The envelope is your FINAL output. Nothing after it.
-2. Do NOT invoke any other SDD skill (via Skill tool or by reading another SKILL.md). Return the envelope; the orchestrator decides next steps.
-
-**Phase-specific guidance:**
-- **Status**: `ok` after successful exploration; `warning` if ambiguities remain unresolved; `blocked` if critical context is missing
-- **Phase**: `explore`
-- **Artifacts**: the exploration file path, e.g. `.sdd/{change-name}/exploration.md`
-- **Next Recommended**: `/sdd-plan {change-name}`
-- **Risks**: include any risks detected during exploration (architectural concerns, missing test coverage, unclear requirements). Use `None` if no risks found.
-- **Engram Ref**: If you persisted to engram in the previous step, include the observation ID as `engram_ref` in the envelope table. Omit if engram was not used.
-
----
-
-**Success Criteria**
-
-✅ **Selection executed** (not just planned) targeting 50–80k but accepting more for completeness
-✅ **Prompt crystallized** with architectural clarity, symbol relationships, and taskname metadata
-✅ **Token budget self-assessed** — agent confirms selection targets 50–80k tokens before completing exploration
-✅ **Architecture understood** through exploration and strategic file reading
-✅ **All relevant context included** with implementation details where needed
-✅ **Envelope returned with correct fields** — status, phase, change, executive summary, artifacts, next recommended, risks
-
-**Anti-patterns to Avoid**
-- 🚫 **CRITICAL: Accumulating all findings to write exploration.md in one giant Write at the end** — this exceeds output token limits and causes infinite loops. ALWAYS use incremental `Edit` calls to update sections as you discover them
-- 🚫 **Assuming a solution and only selecting context for that solution** — the next model may solve it differently
-- 🚫 Narrow slicing based on what YOU think needs changing — include complete context for different approaches
-- 🚫 Using codemap-only for files that require implementation understanding
-- 🚫 Leaving >30% of tokens to codemaps after creating slices
-- 🚫 Not iterating on selection to optimize token usage
-- 🚫 Not reading enough files during exploration to understand the task
-- 🚫 **Skipping final token verification after setting the handoff prompt** — always validate you're within budget before halting
-- 🚫 Excluding important files just to stay under token limits
-- 🚫 Files that might be edited included only as codemaps (need implementation)
-- 🚫 Mentioning files as relevant but not including them in selection
-- 🚫 Forgetting to execute the final selection
-- 🚫 **CRITICAL:** Skipping the handoff prompt entirely—this is a mandatory step
-- 🚫 Proposing solutions or implementation approaches in the handoff prompt
-- 🚫 Implementing the task after setting the context and handoff prompt without explicit user approval
-- 🚫 **Writing implementation code or proposed solutions into exploration.md** — this file is context only; the plan phase decides approach
-- 🚫 **Skipping Step 2 (Jira fetch) when a ticket ID IS provided** — always retrieve requirements before exploring
-
-Remember: You are the scout who maps the territory. The next model depends entirely on your file curation and the clarifying prompt you leave behind. Don't solve the problem—provide complete context so the next model can explore and choose their own solution approach.
+Exclude unrelated functionality, deprecated code, and test fixtures not needed for understanding. Preview each slice before adding it.
 
 ## References
 
-Related SDD workflow skills:
-- [sdd-plan](../sdd-plan/SKILL.md) — next phase: creates implementation plan from this exploration
-- [sdd-implement](../sdd-implement/SKILL.md) — implements the plan
-- [sdd-review](../sdd-review/SKILL.md) — reviews changes against the plan
+Related SDD workflow skills: [sdd-plan](../sdd-plan/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md).
 
-Shared contracts:
-- [Persistence Contract](../_shared/persistence-contract.md) — shared persistence rules for SDD skills
-</meta prompt 1>
 <user_instructions>
 
 - $ARGUMENTS
 
 - change_name: $1
 - instructions: $2
-  </user_instructions>
+</user_instructions>

--- a/workflows/sdd/sdd-implement/SKILL.md
+++ b/workflows/sdd/sdd-implement/SKILL.md
@@ -6,311 +6,126 @@ disable-model-invocation: false
 allowed-tools: Bash, Bash(tree:*), Read, Glob, Grep, Write, Edit, Task, mcp__atlassian__jira_get_issue
 ---
 
-<meta prompt 1 = "System: Senior Developer Agent">
-You are an **autonomous agent**. Make confident decisions, work in small, certain steps, and choose the most efficient path for each task.
+Execute the implementation plan in small, certain steps. Make confident decisions and use tools without asking permission.
 
-**Provenance & State**
-Two critical files contain the context for implementation:
-- `.sdd/{change-name}/exploration.md` — curated context, selected files, and handoff prompt from discovery phase
-- `.sdd/{change-name}/plan.md` — detailed implementation plan with tasks, architecture decisions, and clarifications
+Two files contain the context for implementation:
 
-**Your Operating Philosophy**
-- **Autonomy:** Decide and act without asking permission—you know the tools, use them.
-- **Precision:** Prefer small, certain steps over large, uncertain ones.
+- `.sdd/{change-name}/exploration.md` — curated context, selected files, handoff prompt from the discovery phase.
+- `.sdd/{change-name}/plan.md` — detailed implementation plan with tasks, architecture decisions, and clarifications.
 
-**First Steps (MANDATORY)**
+## First Steps (MANDATORY)
 
-1. **Read the exploration file** from `.sdd/{change-name}/exploration.md` to understand:
-    - Selected files and their relationships
-    - Handoff prompt with task requirements
-    - Architecture context
-
-2. **Be prepared**: In some cases, the plan may not exist since the feature is too simple.
-
-3. **Read the implementation plan (if exists)** from `.sdd/{change-name}/plan.md` to understand:
-    - Detailed implementation tasks
-    - Files to modify
-    - Clarifications and decisions made during planning
-
-4. **Pre-flight Detail Check (WARNING — non-blocking)**
-
-   After reading plan.md, quickly scan the Implementation Tasks section:
-    - Do non-trivial tasks have `**Details for TXXX**:` blocks?
-    - Does Section 2 have populated Contract Specifications (if new types exist)?
-    - Are Before/After states documented for modification tasks?
-
-   If detail is sparse, note this in your implementation log but DO NOT block execution.
-   Work with whatever detail is available and make reasonable design decisions.
-   Plans created before the detail quality improvements may lack these sections.
-
-**Engram Recovery Fallback**: If `exploration.md` or `plan.md` is not found, and engram tools are available, use the **mandatory two-step recovery** pattern (`mem_search` returns truncated ~300-char previews — you MUST follow with `mem_get_observation` to get full content):
-
-1. For exploration:
-    - Step 1: `mem_search(query: "sdd/{change-name}/explore", project: "{project}")` — returns observation ID + truncated preview
-    - Step 2 (REQUIRED): `mem_get_observation(id: {observation-id from step 1})` — returns complete, untruncated content
-2. For plan:
-    - Step 1: `mem_search(query: "sdd/{change-name}/plan", project: "{project}")` — returns observation ID + truncated preview
-    - Step 2 (REQUIRED): `mem_get_observation(id: {observation-id from step 1})` — returns complete, untruncated content
-
-**NEVER** use `mem_search` results directly as artifact content. The preview is always truncated and incomplete.
-
-Use recovered content as context. If neither file nor engram has the required artifact, return envelope with `status: blocked`.
+1. **Read** `.sdd/{change-name}/exploration.md` for selected files, relationships, and architecture context.
+2. The plan file may not exist when the feature is too simple. **Read** `.sdd/{change-name}/plan.md` if present for detailed tasks, file targets, and clarifications.
+3. **Pre-flight detail check (non-blocking)**: scan plan.md's Implementation Tasks section. If non-trivial tasks lack `**Details for TXXX**:` blocks, Section 2 is missing Contract Specifications when new types exist, or Before/After is absent for modification tasks — note it in your implementation log but do not block. Plans created before the detail-quality improvements may lack these sections; work with whatever detail is available and make reasonable design decisions.
+4. **Engram fallback**: if `exploration.md` or `plan.md` is missing, recover via the two-step pattern in `_shared/persistence-contract.md`. If neither file nor engram has the artifact, return envelope with `status: blocked`.
 
 ## Batch Execution (wave-scoped)
 
-Your launch prompt from the orchestrator specifies the batches you own. Honor that scope.
+The orchestrator's launch prompt specifies which batches you own. Honor that scope.
 
 ### Wave-scoped mode (default when launched by orchestrator)
 
 The prompt contains one of:
-  - `Batches: A, B` (parallel batches in this wave — you own ALL listed batches)
-  - `Batch: C` (single sequential batch)
-  - `Previously completed batches: X, Y` (do not re-execute these)
+- `Batches: A, B` — parallel batches in this wave; you own ALL listed
+- `Batch: C` — single sequential batch
+- `Previously completed batches: X, Y` — do not re-execute these
 
 Rules:
+
 1. Implement tasks in the listed batch(es) in the order given by the Batch Assignment Table.
 2. Execute tasks within each batch sequentially (same file).
-3. Between batches in the same wave (if prompt lists multiple): sequential is safe.
-4. NEVER infer additional batches or launch Task()/Agent() to implement them.
-5. Quality gate: after the LAST task of each batch, run the Phase Checkpoint from plan.md.
-6. Mark [X] as each task completes.
-7. Return envelope with status reflecting this wave only.
+3. Between batches in the same wave, sequential is safe.
+4. NEVER infer additional batches or launch `Task()`/`Agent()` to implement them — the orchestrator owns wave progression.
+5. Mark `[X]` in `plan.md` IMMEDIATELY as each task completes (not in bulk at the end).
+6. After the LAST task of each batch, run the Phase Checkpoint from `plan.md` for that batch's phase. If any Checkpoint bullet fails: STOP, return envelope with `status: failed`.
+7. Return envelope with status reflecting THIS wave only.
 
 ### Standalone fallback mode (no batch directive in prompt)
 
-If the prompt has no "Batch:" / "Batches:" directive:
-1. Read the full Batch Assignment Table from plan.md.
-2. Execute all batches sequentially (ignore Parallel=Yes — no Task() self-orchestration).
-3. Run Phase Checkpoints after each batch.
-4. Mark [X] as each task completes.
-5. Return envelope when all batches done.
+If the prompt has no `Batch:` / `Batches:` directive:
+
+1. Read the full Batch Assignment Table from `plan.md`.
+2. Execute all batches sequentially (ignore `Parallel=Yes` — no `Task()` self-orchestration here).
+3. Run Phase Checkpoints after each batch, marking `[X]` per task.
+4. Return envelope when all batches done.
 
 This fallback preserves backward compatibility for direct skill invocations (e.g. `/sdd-implement {change}`).
 
-**Explore & Understand (as needed)**
+## Implementation Notes
 
-- **Map structure fast:** use `tree` bash command (adapts depth to size, shows all roots when no `path` is given).
-
-  ```bash
-  tree --gitignore -L 6
-  ```
-
-  Drill down into a directory by adding `path` (optionally bound the depth):
-
-  ```bash
-  tree --gitignore -L 3 path/to/subdirectory
-  ```
-
-* **Surface symbols/usages/paths:** `Read`, `Glob`, `Grep`
-* **Summarize APIs:** `Grep`, `Read` on key paths
-
-**Slices doctrine (when selection must stay lean)**
-- MUST read the relevant sections with `Grep` before slicing
-- Use Read with offset and limit parameters to extract relevant sections. Always include surrounding context (imports, class declaration) so the slice is self-contained.
-- Prefer 80–150+ line self-contained slices over micro-fragments
-- If you omit critical context, the task will fail
-
-**Implement Changes**
-
-Go straight to `Edit` when the change is clear. Examples:
-
-- Edit Root/File.java to replace all occurrences of "OldService" with "NewService".
-- Write Root/newFile.java with the provided implementation details.
-- **Tracking progress (NOT OPTIONAL)**: Always mark plan tasks as done when implemented and validated -> [X]
-    - After each batch completes successfully, mark ALL its tasks as `[X]` in plan.md
-
-**Architecture Planning (optional)**
-If you need a high-level plan, check if an architect advisor skill is installed (e.g., `*-architect-advisor`) and use it as a subagent. File selection is essential before doing so:
-
-```text
-Plan: Outline the approach to migrate X → Y given the following files.
-- Root/src/feature
-- Root/src/shared/types
-```
-
-**Multi-Root Hygiene (efficient)**
-
-* The context session may already list roots—scan the provenance banner and partial tree first; no extra call needed.
-* To (re)surface all roots, call `tree --gitignore -L 6` **without** a `path`, e.g.
-  ```bash
-  tree --gitignore -L 6
-  ```
-* Drill down by adding `path:"<RootName>/subdir"` to focus on a specific area.
-
-**Operational Notes**
-
-* File selection and scope are defined in plan.md — stay within that scope. Do not explore or modify files outside the planned boundaries.
-* Verify results with targeted `Read` slices and follow-up `Grep` checks when helpful.
-
----
-
-## Large File Creation Strategy (MANDATORY)
-
-When creating NEW files that will exceed ~150 lines:
-
-1. **Write** the file with scaffolding + first logical section only (~100-150 lines max)
-2. **Edit** to append each remaining section incrementally
-3. **Never** send >200 lines in a single Write call — large payloads cause permission hook timeouts
-
-When a Write or Edit call **FAILS** (timeout, rejected, permission error):
-
-1. **Do NOT retry the same call** — retrying identical failing calls wastes turns
-2. **Split the content in half** and try smaller chunks
-3. If still failing after 2 split retries, return envelope with `status=failed` and include the blocked file path in risks
-
-This prevents permission hook timeouts on large content and avoids wasting turns in retry loops.
-
----
+- **Surface symbols/usages/paths** with `Read`, `Glob`, `Grep`. Map structure with `tree --gitignore -L 6` (drill with `path/to/subdirectory` and depth `-L 3` as needed).
+- **Stay within plan scope.** File selection is defined in `plan.md`. Do not explore or modify files outside the planned boundaries.
+- **Slices**, when needed: read with `Grep`/`Read` first, prefer 80–150+ line self-contained sections, always include surrounding context (imports, class declaration). Omitting critical context fails the task.
+- **Architecture planning** (optional): if a design decision needs specialist input, invoke an `*-advisor` skill as a sub-agent with the relevant file selection. Do not invoke other SDD phase skills.
 
 ## Quality Gate (per-batch, driven by plan Phase Checkpoints)
 
-After the LAST task of each batch completes, run the Phase Checkpoint for that batch's phase.
+After the LAST task of each batch:
 
-1. Locate the `**Checkpoint**:` block in plan.md that covers the batch's phase.
-2. Each bullet under the Checkpoint is a verifiable assertion — translate to a shell command
-   where possible:
-   - "Project builds without errors" → detect build runner, run it
-   - "All N integration test scenarios pass" → run the test runner
-   - "Linting passes" → run the linter
-3. If a Checkpoint bullet does not translate to a command (e.g. "documentation updated"),
-   verify by re-reading the relevant file.
-4. If ANY Checkpoint bullet fails: STOP, return envelope with `status: failed`.
-5. If the plan defines no Checkpoint for this batch's phase, default to runner-detected
-   `build` + `test` commands.
+1. Locate the `**Checkpoint**:` block in `plan.md` for the batch's phase.
+2. Each bullet is a verifiable assertion — translate to a shell command where possible:
+   - "Project builds without errors" → detect the build runner, run it.
+   - "All N integration test scenarios pass" → run the test runner.
+   - "Linting passes" → run the linter.
+3. If a bullet doesn't translate to a command (e.g. "documentation updated"), verify by re-reading the relevant file.
+4. If ANY bullet fails: STOP, return envelope with `status: failed`.
+5. If `plan.md` defines no Checkpoint for this batch's phase, default to runner-detected `build` + `test`.
 
-**The quality gate is per-batch, not per-task.** Per-task test runs are wasteful and the
-old rule is REMOVED.
+The gate is **per-batch, not per-task**.
 
----
+## Large File Creation (mandatory)
 
-## Engram Persistence (Optional — Complementary to .sdd/ Files)
+When creating NEW files that will exceed ~150 lines:
 
-After all tasks are complete and post-implementation verification passes, persist a progress summary to engram if available.
+1. `Write` the file with scaffolding + first logical section only (~100–150 lines max).
+2. `Edit` to append each remaining section incrementally.
+3. Never send >200 lines in a single `Write` — large payloads cause permission hook timeouts.
 
-**Availability guard**: Check whether engram tools (`mem_save`) exist as callable tools. If they do NOT exist, skip this entire section silently — do NOT error, do NOT warn the user.
+When a `Write` or `Edit` call **fails** (timeout, rejected, permission error):
 
-If engram tools ARE available:
+1. Do NOT retry the same call — retrying identical failing calls wastes turns.
+2. Split the content in half and try smaller chunks.
+3. If still failing after 2 split retries, return envelope with `status: failed` and include the blocked file path in `risks`.
 
-```
-mem_save(
-  title: "sdd/{change-name}/implement-progress",
-  topic_key: "sdd/{change-name}/implement-progress",
-  type: "architecture",
-  project: "{project-name from context}",
-  content: "# Implementation Progress: {change-name}\n\n## Completed Tasks\n{list all [X] tasks from plan.md}\n\n## Status\n{ok/failed + brief explanation}\n\n## Files Modified\n{list of files changed}"
-)
-```
+## Persistence
 
-If engram tools are NOT available, skip this step silently. Never let engram unavailability block the workflow.
+Save the implement-progress artifact and any general-knowledge discoveries (bug fixes, gotchas, conventions) per `_shared/persistence-contract.md` (Phase Artifact Save Convention + General Knowledge Persistence Mandate). For this phase, `title`/`topic_key` is `sdd/{change}/implement-progress`.
 
-Note the observation ID returned by `mem_save` — include it as `engram_ref` in your envelope if available.
+## Return Envelope
 
----
+Return the SDD Envelope as your **last** output (format: `_shared/envelope-contract.md`). Nothing may follow it.
 
-## General Knowledge Persistence (Optional — When Engram Available)
+| Field            | Value                                                                                          |
+|------------------|------------------------------------------------------------------------------------------------|
+| Status           | `ok` (all wave tasks pass + Phase Checkpoint succeeds) · `failed` (any task or Checkpoint fails) |
+| Phase            | `implement`                                                                                    |
+| Change           | `{change-name}`                                                                                |
+| Artifacts        | `.sdd/{change-name}/plan.md` (with `[X]` markers showing this wave's completed tasks)          |
+| Next Recommended | `/sdd-review {change-name}`                                                                    |
+| Risks            | Flaky tests, deprecation notices, partial coverage; or "None"                                  |
+| Engram Ref       | Observation ID from the persistence step, or omit if engram unavailable                        |
 
-Beyond the SDD phase artifact above, if you discovered important knowledge during implementation that would benefit future sessions, save it to engram:
+Do NOT invoke commit/review/any other SDD skill — return the envelope; the orchestrator decides next steps.
 
-- Bug fixes and their root causes
-- Code patterns established or conventions discovered
-- Build/test gotchas or workarounds
-- Architecture constraints discovered during implementation
+## Self-Check (before returning the envelope)
 
-For each:
-```
-mem_save(
-  title: "{short searchable description}",
-  type: "{bugfix|decision|discovery|pattern}",
-  project: "{project-name}",
-  content: "**What**: {description}\n**Why**: {reasoning}\n**Where**: {files affected}\n**Learned**: {gotchas or edge cases}"
-)
-```
-
-If engram tools are NOT available, skip silently.
-
----
-
-## Return Envelope (MANDATORY)
-
-See [envelope contract](../_shared/envelope-contract.md) for format.
-
-Your LAST output MUST be the SDD Envelope. Nothing may follow it.
-
-**Rules:**
-1. The envelope is your FINAL output. Nothing after it.
-2. Do NOT invoke any other SDD skill (via Skill tool or by reading another SKILL.md). Return the envelope; the orchestrator decides next steps.
-
-**Phase-specific guidance for implement:**
-
-| Field | Value |
-|-------|-------|
-| **Status** | `ok` when ALL tasks pass quality gate and post-implementation verification succeeds. `failed` if ANY task fails its quality gate or build breaks. |
-| **Phase** | `implement` |
-| **Change** | `{change-name}` |
-
-- **Artifacts**: Include `plan.md` with `[X]` markers showing completed tasks (path: `.sdd/{change-name}/plan.md`)
-- **Engram Ref**: If you persisted to engram in the previous step, include the observation ID as `engram_ref` in the envelope table. Omit if engram was not used.
-- **Next Recommended**: `/sdd-review {change-name}`
-- **Risks**: Include any warnings encountered during implementation (flaky tests, deprecation notices, partial coverage). Use "None" if clean.
-
----
-
-## Success Criteria
-
-✅ **Both context files read** — exploration.md AND plan.md
-✅ **All plan tasks completed** — every task from the plan is implemented
-✅ **Batch execution followed** — Batch Assignment Table used to determine parallelism and ordering
-✅ **Quality gate passed per batch** — Phase Checkpoint from plan.md verified after each batch's last task
-✅ **Code compiles/builds** — no syntax errors or build failures
-✅ **Tests pass** — if tests exist, they should pass
-✅ **No regressions** — existing functionality still works
-✅ **Envelope returned with correct fields** — status, phase, change, artifacts, next_recommended, risks
-
-## Gotchas
-
-- **Writing large files (>150 lines) in a single Write call** — split into Write (scaffolding, ~100-150 lines) then Edit to append remaining sections. Never send >200 lines in one Write; large payloads cause permission hook timeouts that waste turns.
-- **Retrying identical failed tool calls** — if Write/Edit fails, split the content in half rather than retrying the same call. Retrying an identical call that already failed will fail again for the same reason.
-- **Skipping the quality gate** — run tests or build after EVERY task, not just at the end. A failed quality gate means stop immediately; continuing after failure compounds broken state across multiple tasks.
-- **Executing parallel batches sequentially** — when the Batch Assignment Table shows `Parallel=Yes`, launch ALL ready parallel batches as simultaneous Task calls in a single message. Sequential execution of parallel batches wastes time.
-- **Ignoring the Batch Assignment Table** — never define or infer parallelism from task text. The table is the single source of truth for execution order and parallelism.
-- **Forgetting to mark [X]**: Sub-agents frequently skip marking tasks as [X] in plan.md after completing them. This breaks traceability and forces manual cleanup. After EVERY successfully completed task, immediately Edit plan.md to change [ ] to [X] for that task. Do this per-task, not at the end.
-
-## Anti-patterns to Avoid
-
-- 🚫 **Skipping exploration.md** — this contains critical context from discovery
-- 🚫 **Skipping plan.md** — this contains the detailed implementation tasks
-- 🚫 **Large, uncertain changes** — prefer small, verified steps
-- 🚫 **Not verifying changes** — always run build/lint/tests after implementation
-- 🚫 **Implementing without reading plan tasks** — follow the plan systematically
-- 🚫 **Skipping tracking progress** — always mark plan tasks as done when implemented and validated
-- 🚫 **Leaving broken code** — fix any issues before marking as complete
-- 🚫 **Executing parallel batches sequentially** — use Task tool to launch parallel batches simultaneously
-- 🚫 **Ignoring Batch Assignment Table** — always read and follow the table from plan.md
-- 🚫 **Continuing after batch failure** — fail-fast: stop immediately if any task in any batch fails
-- 🚫 **Skipping tests when test runner exists** — if a test runner is detected, tests MUST run after each task
-- 🚫 **Continuing after test failure** — a failed quality gate means STOP, do not proceed to next task
-- 🚫 **Writing large files in a single call** — split files >150 lines into Write (scaffolding) + Edit (append sections); never send >200 lines in one Write call
-- 🚫 **Retrying identical failed tool calls** — if Write/Edit fails, split content into smaller chunks instead of retrying the same payload
-- 🚫 **Completing tasks without marking [X] in plan.md** — this is the #1 traceability failure. Mark EACH task as [X] immediately after it passes quality gate, not in bulk at the end. The orchestrator and future sessions rely on [X] markers to know what was done.
-- 🚫 **Invoking commit or review skills directly** — return the envelope; the orchestrator handles next steps
+- Both `exploration.md` and `plan.md` were read.
+- Tasks were implemented strictly within the wave/batch scope from the launch prompt; no additional batches were launched or inferred.
+- Each completed task has `[X]` in `plan.md` (uppercase X — lowercase `[x]` is treated as incomplete by the parser).
+- The Phase Checkpoint for this batch's phase was run (not a generic suite); a failed Checkpoint produced `status: failed` and stopped further work.
+- For NEW files >150 lines: scaffolding via `Write` first, sections appended via `Edit`. No `Write` payload exceeded ~200 lines.
+- Failed `Write`/`Edit` calls were split in half, not retried identically.
+- Did not edit files outside `plan.md`'s scope.
 
 ## References
 
-Related SDD workflow skills:
-- [sdd-explore](../sdd-explore/SKILL.md) — previous phase: discovery and file curation
-- [sdd-plan](../sdd-plan/SKILL.md) — previous phase: implementation planning
-- [sdd-review](../sdd-review/SKILL.md) — next phase: review changes against the plan
+Related SDD workflow skills: [sdd-explore](../sdd-explore/SKILL.md), [sdd-plan](../sdd-plan/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Specialist skills: any installed `*-advisor`. Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md).
 
-Related specialist skills (for subagent invocation):
-- Any installed advisor skills matching `*-advisor` pattern -- discovered dynamically from the skills directory
-
-Shared contracts:
-- [Persistence Contract](../_shared/persistence-contract.md) — shared persistence rules for SDD skills
-</meta prompt 1>
 <user_instructions>
 
 - $ARGUMENTS
 
 - change_name: $1
 - instructions: $2
-  </user_instructions>
+</user_instructions>

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -6,107 +6,79 @@ disable-model-invocation: false
 allowed-tools: Bash, Bash(tree:*), Read, Glob, Grep, Write, Edit, AskUserQuestion, Skill, Task, mcp__atlassian__jira_get_issue, Bash(crit:*)
 ---
 
-<meta prompt 1 = "System: Architect">
-You are a senior software architect specializing in code design and implementation planning. Your role is to:
+Create the implementation plan for the next phase. The plan file is your entire world: the implementer (a different model with no memory of this session) depends entirely on `plan.md` for design decisions. Do not implement.
 
-1. Read exploration file from `.sdd/{change-name}/exploration.md` to gather all the context about the feature to be implemented
+## Re-entry Paths (check BEFORE the main flow)
 
-   **Engram Recovery Fallback**: If `exploration.md` is not found or is incomplete, and engram tools are available, use the mandatory **TWO-STEP** recovery pattern (`mem_search` returns truncated ~300-char previews — NEVER use search results directly as artifact content):
-   1. `mem_search(query: "sdd/{change-name}/explore", project: "{project}")` → get observation ID from results (preview only — truncated, incomplete)
-   2. `mem_get_observation(id: {observation-id})` → full, untruncated exploration summary (REQUIRED — always follow search with get)
-      Use this recovered content as your exploration context. If neither file nor engram has the exploration, return envelope with `status: blocked` and explain the missing dependency.
+- **Crit Re-entry**: if the launch prompt contains a `CRIT_FEEDBACK:` block → follow Crit Feedback Re-entry below.
+- **Guidance Re-entry**: if the launch prompt contains a `GUIDANCE:` block → jump to step 8 (Guidance Integration).
+- **Neither block** → proceed with the main flow from step 1.
 
-## Re-entry Paths (MANDATORY — check BEFORE proceeding to main flow)
+### Crit Feedback Re-entry
 
-   **Crit Re-entry**: If `CRIT_FEEDBACK:` block found in launch prompt → follow Crit Feedback Re-entry steps below.
-   **Guidance Re-entry**: If `GUIDANCE:` block found in launch prompt → go to step 8 (Guidance Integration).
+1. Read the existing `.sdd/{change}/plan.md` (do NOT start from scratch).
+2. For each unresolved comment in the `CRIT_FEEDBACK:` block:
+   a. Locate the referenced section/lines in plan.md.
+   b. Revise the plan to address the feedback.
+   c. Reply: `crit comment --plan {change} --reply-to {id} --author 'Claude Code' '<what was changed>'` (`Bash(crit:*)` is allowed).
+3. Skip the Deep Interview (already completed in the initial pass).
+4. Re-evaluate Team Selection — if crit feedback introduces concerns that warrant specialist review, update `## Team Selection`.
+5. Re-run the Detail Quality Gate.
+6. Return `status: guidance_requested` if step 4 added new advisors; otherwise `status: ok`.
 
-   If neither block is present → proceed with main flow from step 1.
+## Main Flow
 
-   **Crit Feedback Re-entry**: If the launch prompt contains a `CRIT_FEEDBACK:` block:
-   1. Read the existing `.sdd/{change}/plan.md` (do NOT start from scratch)
-   2. For each unresolved comment in the CRIT_FEEDBACK block:
-      a. Locate the referenced section/lines in plan.md
-      b. Revise the plan to address the feedback
-      c. Reply to the comment: `crit comment --plan {change} --reply-to {id} --author 'Claude Code' '<what was changed>'`
-   3. Skip the Deep Interview (already completed in the initial plan pass)
-   4. Re-evaluate Team Selection: if the crit feedback introduces new concerns that
-      would benefit from specialist review (e.g. "get architect input on this pattern",
-      "testing strategy needs review"), update the `## Team Selection` section.
-   5. Re-run the Detail Quality Gate on the revised plan
-   6. If Team Selection added new advisors in step 4 → return `status: guidance_requested`
-      (same as step 7 — orchestrator will launch advisors and re-enter with guidance).
-      If no new advisors needed → return `status: ok` envelope.
+1. **Read exploration context** from `.sdd/{change-name}/exploration.md`.
 
-   The `Bash` tool with `crit comment --plan` is required for replying. `Bash(crit:*)` is included in allowed-tools for this purpose.
+   If `exploration.md` is missing or incomplete, recover via the two-step pattern in `_shared/persistence-contract.md`. If neither file nor engram has it, return envelope with `status: blocked`.
 
-2. Create plan file `.sdd/{change-name}/plan.md`
-   - Use the plan template from [templates/plan_template.md](templates/plan_template.md) as a template do not omit any section
-3. Deep Interview Phase (MANDATORY — Using AskUserQuestion Tool)
-   
-   Complexity check: If the exploration.md describes a change touching ≤3 files with no cross-layer impact, skip the Deep Interview and proceed directly to Architecture Analysis (step 4). Document 'Interview skipped — simple change (≤3 files, single layer)' in the Clarifications section (## 4. Clarifications).
-   
-   Before analyzing architecture or selecting advisors, conduct an in-depth interview with the user to surface requirements, constraints, tradeoffs, and design decisions that exploration.md alone cannot capture.
+2. **Create plan file** `.sdd/{change-name}/plan.md` from [templates/plan_template.md](templates/plan_template.md). Do not omit any section.
 
-   Follow the complete interview methodology in [references/interview_guide.md](references/interview_guide.md), which covers:
-   - **Interview Dimensions** — 10 dimensions to explore (behavioral contracts, hidden constraints, tradeoff tensions, failure modes, integration surface, contract specification, data lifecycle, UX/DX decisions, observability, evolution path)
-   - **Question Generation Rules** — 5 filters every question must pass to ensure non-obvious, insightful questions
-   - **Interview Loop Mechanics** — iterative multi-round loop with minimum 2 rounds before offering to end
+3. **Deep Interview Phase** (MANDATORY)
 
-   **Key rules**:
-   - Every question must EXPOSE a hidden decision, CHALLENGE assumptions, or FORCE prioritization — never ask obvious questions
-   - Use `AskUserQuestion` with up to 4 questions per call, each with 2-4 options and recommended option first
-   - Record each answer in the plan under `## 4. Clarifications` with format: `- **[Dimension]**: Q: <question> → A: <answer>`
-   - Do NOT proceed to step 4 until the interview loop has completed
+   Complexity check: if `exploration.md` describes a change touching ≤3 files with no cross-layer impact, skip the Deep Interview and proceed to step 4. Document `Interview skipped — simple change (≤3 files, single layer)` in `## 4. Clarifications`.
 
-4. Analyze the requested changes and break them down into clear, actionable steps
-5. Team Selection (record which advisors are needed — do NOT invoke yet)
+   Otherwise, conduct an in-depth interview before architecture analysis. Follow the methodology in [references/interview_guide.md](references/interview_guide.md): 10 dimensions to explore, 5 question filters, iterative loop with minimum 2 rounds.
 
-   **Specialist Skills for Planning Advice:**
+   Key rules:
+   - Every question must EXPOSE a hidden decision, CHALLENGE assumptions, or FORCE prioritization — never ask obvious questions.
+   - Use `AskUserQuestion` (up to 4 questions per call, 2-4 options each, recommended option first).
+   - Record each answer in `## 4. Clarifications` as: `- **[Dimension]**: Q: <question> → A: <answer>`.
+   - Do NOT proceed to step 4 until the interview loop has completed.
+
+4. **Analyze the requested changes** and break them into clear, actionable steps.
+
+5. **Team Selection** (record only — do NOT invoke advisors yet)
 
    <!-- ADVISOR_TABLE_PLACEHOLDER -->
 
-   If no advisor skills are listed above, skip steps 5 and 7 (Team Selection and Guidance Request) and proceed directly to step 6 (Implementation Plan).
+   If no advisor skills are listed above, skip steps 5 and 7 and proceed to step 6.
 
-   Review the feature requirements and identify which specialist skills are relevant.
-   Record selections in `## Team Selection` section with reasoning.
-   These selections will be returned in the envelope at step 7 if guidance is needed.
-   Do NOT invoke Task() or Skill() for advisors here — that is handled by the orchestrator.
+   Process:
+   1. Identify which architectural layers are affected.
+   2. Select relevant advisors from the table.
+   3. Document selections in `## Team Selection` with reasoning.
 
-   **Selection Process:**
-   1. Analyze the feature requirements from exploration.md
-   2. Identify which architectural layers are affected
-   3. Select relevant skills from the table above
-   4. Document selections in the plan under `## Team Selection` section with reasoning
+   Do NOT invoke `Task()`/`Skill()` for advisors here — that's the orchestrator's job.
 
-6. Create a detailed implementation plan that includes:
-   - Files that need to be modified
-   - Specific code sections requiring changes
-   - New functions, methods, or classes to be added
-   - Dependencies or imports to be updated
-   - Data structure modifications
-   - Interface changes
-   - Configuration updates
+6. **Implementation plan** — files to modify, code sections, new functions/methods/classes, dependencies, data structures, interfaces, configuration changes.
 
-   **Task Format (CRITICAL — machine-parsed by sdd-implement)**:
-   Every task in the plan MUST follow this exact format:
+   **Task format (CRITICAL — machine-parsed by sdd-implement)**:
+
    `- [ ] TXXX [TAGS]? Description — file_path`
 
-   - `[ ]` = incomplete (space inside brackets), `[X]` = complete (uppercase X only, never `[x]`)
-   - `TXXX` = T + 3-digit zero-padded number (T001, T002, ...), sequential across ALL phases
-   - `[TAGS]` = optional user story tags like `[US1]`, `[US2]`
-   - Each task MUST reference its target file path after an em-dash (—, not hyphen -)
-   - See [templates/plan_template.md](templates/plan_template.md) for the complete specification with valid/invalid examples
+   - `[ ]` = incomplete (space inside), `[X]` = complete (uppercase X only — `[x]` is treated as incomplete).
+   - `TXXX` = T + 3-digit zero-padded number (T001, T002, …), sequential across ALL phases.
+   - `[TAGS]` optional, e.g. `[US1]`.
+   - Each task MUST reference its target file path after an em-dash (—, not hyphen `-`).
+   - See [templates/plan_template.md](templates/plan_template.md) for the full spec with examples.
 
-   This format is NOT optional. The `sdd-implement` skill parses these markers to:
-   1. Track progress via `[ ]` → `[X]` transitions
-   2. Resume implementation across sessions
-   3. Execute tasks in batch order (see Batch Assignment Table below)
+   The format is NOT optional — `sdd-implement` parses these markers to track progress, resume across sessions, and execute in batch order.
 
-   **Batch Assignment Table (MANDATORY)**:
-   After ALL tasks are defined, you MUST include a Batch Assignment Table. This table is the **SINGLE source of truth** for parallelism and execution order. Parallelism is NEVER defined inline in tasks — only in this table.
+   **Batch Assignment Table** (MANDATORY)
 
-   Format:
+   After all tasks are defined, include a Batch Assignment Table — the **single source of truth** for parallelism and execution order. Parallelism is NEVER defined inline in tasks.
+
    ```
    | Batch | Tasks | File | Parallel | Depends on |
    |-------|-------|------|----------|------------|
@@ -115,251 +87,114 @@ You are a senior software architect specializing in code design and implementati
    | C | T006 | src/Service.java | No | A, B |
    ```
 
-   **Rules**:
-   - Group by target file: all tasks on the same file belong to the same batch (sequential within the batch)
-   - Batches on different files with no cross-dependencies can run in parallel (`Parallel=Yes`)
-   - If ALL batches are sequential (single file or linear deps), the table still documents execution order
-   - The table is DERIVED from the tasks — not new information. After defining tasks, scan file paths and group automatically
-   - `sdd-implement` reads this table to decide batch execution strategy
+   - Group by target file: tasks on the same file belong to the same batch (sequential within the batch).
+   - Batches on different files with no cross-dependencies can run in parallel (`Parallel=Yes`).
+   - If all batches are sequential, the table still documents execution order.
 
-   **Detail Quality Gate (MANDATORY — self-check before proceeding to step 7)**:
+   **Detail Quality Gate** (self-check before step 7)
 
-   Before proceeding to the Guidance Request step, verify your plan meets the detail quality bar:
+   Before requesting guidance, verify:
 
-   1. **Task Detail Blocks**: Every non-trivial task has a `**Details for TXXX**:` block immediately after the task line. Trivial tasks (renaming, import-only, config toggle) may omit it. When in doubt, include it.
-   2. **Contract Specifications**: If the plan introduces new types, interfaces, or data schemas, Section 2 must have a populated "Contract Specifications" subsection with exact signatures in code blocks.
-   3. **Before/After Analysis**: If the plan modifies existing code or configuration, Section 2 must have a populated "Before/After Analysis" subsection showing current state → proposed state for each modified component.
-   4. **Testable Checkpoints**: Every phase checkpoint includes specific, verifiable criteria (not just "story complete" — list what can be tested).
+   1. **Task Detail Blocks** — every non-trivial task has a `**Details for TXXX**:` block with signatures, types, or schema. Trivial tasks (rename, import-only, config toggle) may omit it.
+   2. **Contract Specifications** — if the plan introduces new types/interfaces/schemas, Section 2 has a populated "Contract Specifications" with exact signatures.
+   3. **Before/After Analysis** — modification tasks show current → proposed state in Section 2's "Before/After Analysis".
+   4. **Testable Checkpoints** — every phase Checkpoint lists specific verifiable criteria.
 
-   If any check fails, go back and add the missing detail before continuing.
-   The implementer (a different model with no memory of this session) depends entirely on plan.md for design decisions.
+   If any check fails, fill the missing detail before continuing.
 
-7. Guidance Request
+7. **Guidance Request**
 
-   **Rule: if Team Selection (step 5) selected any advisors → return `guidance_requested`.**
+   Rule: if Team Selection (step 5) chose any advisors → return `status: guidance_requested`. This is the ONLY condition.
 
-   This is the ONLY condition. If step 5 identified advisors, you MUST request guidance — do not second-guess the selection. If step 5 selected zero advisors, return `status: ok` directly.
+   In the envelope:
+   - `requested_advisors`: comma-separated list of all advisor skill names from step 5.
+   - `guidance_context`: 1-2 sentences per advisor naming what they should focus on (reference task IDs or section names from the plan).
 
-   **What to include in the envelope:**
-   - `requested_advisors`: comma-separated list of ALL advisor skill names selected in step 5
-   - `guidance_context`: for EACH requested advisor, 1-2 sentences describing what they should focus on. Be specific — reference task IDs, section names, or design decisions from the plan.
+   Do NOT request guidance when re-entered with a `GUIDANCE:` block (skip to step 8) or when step 5 selected zero advisors.
 
-   **When NOT to request guidance:**
-   - When re-entered with a `GUIDANCE:` block (guidance already collected — skip to step 8)
-   - When step 5 selected zero advisors
+8. **Guidance Integration Re-entry** (triggered by `GUIDANCE:` block in launch prompt)
 
-8. Guidance Integration Re-entry (TRIGGERED when `GUIDANCE:` block found in launch prompt)
+   1. Read existing `plan.md` (do NOT recreate).
+   2. For each advisor entry in the `GUIDANCE:` block:
+      - If the entry has an `engram ID` → call `mem_get_observation(id)` for full advice.
+      - If inline text → read directly.
+      - Assess each recommendation: relevant to scope? affects task quality?
+      - Integrate applicable recommendations: update task Detail Blocks, add tasks if a critical gap was identified, revise Before/After Analysis, update Section 2 Contract Specifications.
+   3. Update `## Advice Received`: document what was integrated and what was skipped (with rationale).
+   4. Re-run the Detail Quality Gate.
+   5. Return `status: ok` (or `warning` if recommendations could not be fully integrated).
 
-   When re-launched by the orchestrator with a `GUIDANCE:` block in the prompt:
+   Skip Deep Interview / Team Selection / Guidance Request — already done. NEVER return `status: guidance_requested` from a guidance re-entry (would loop infinitely).
 
-   1. Detect: check if the launch prompt contains `GUIDANCE (Round N):` block.
-   2. Read existing plan.md (do NOT start from scratch — revise only).
-   3. For each advisor entry in GUIDANCE block:
-      a. If entry has `engram ID`: call `mem_get_observation(id)` to fetch full advice.
-      b. If entry is inline text: read directly.
-      c. Assess each recommendation: relevant to scope? affects task quality?
-      d. Integrate applicable recommendations:
-         - Update task Detail Blocks with revised signatures or schemas
-         - Add new tasks if a critical gap was identified
-         - Revise Before/After Analysis if architecture patterns changed
-         - Update Section 2 Contract Specifications if new interfaces emerged
-   4. Update `## Advice Received` section: document what was integrated and what was skipped (with rationale).
-   5. Re-run Detail Quality Gate (step 6 checks).
-   6. Return `status: ok` envelope (or `warning` if recommendations could not be fully integrated).
+## For each change
 
-   **Skips**: Deep Interview, Team Selection, Guidance Request step (already done).
-   **NEVER** return `status: guidance_requested` from a guidance re-entry (prevents infinite loop).
+- Describe the exact location in the code where changes are needed.
+- Explain the logic and reasoning behind each modification.
+- Provide example signatures, parameters, and return types.
+- Note any potential side effects or impacts on other parts of the codebase.
+- Highlight critical architectural decisions that need to be made.
 
-**For each change**:
-- Describe the exact location in the code where changes are needed
-- Explain the logic and reasoning behind each modification
-- Provide example signatures, parameters, and return types
-- Note any potential side effects or impacts on other parts of the codebase
-- Highlight critical architectural decisions that need to be made
+## How to write the plan file
 
-**Iterate**
-Evaluate the plan and iterate over it until have the final plan with the highest quality possible
-**Always** update the plan file `.sdd/{change-name}/plan.md` after each iteration
+Use one `Edit` call per section to replace `[PENDING]` with actual content. Do NOT write the entire plan in one `Write`/`Edit` — large payloads cause timeouts.
 
-**RULES**
-The target of this session is to create the plan DON'T implement it
-This file is your entire world. The next model depends on it
-
-**Output**:
-The comprehensive implementation plan must be written to `.sdd/{change-name}/plan.md` - this is mandatory.
-
-**CRITICAL - How to Write the Plan File (to avoid issues)**:
-
-Use this incremental approach:
-
-- **Fill Content Incrementally (Multiple Edit calls)**
-- For EACH section, use ONE Edit tool call to replace `[PENDING]` with actual content:
-
-1. Edit to fill Section 1 (Overview) - max 50 lines
-2. Edit to fill Section 2 (Architecture) - max 50 lines
-3. Edit to fill Section 3 (Implementation Tasks)
-4. Edit to fill Section 4 (Clarifications) - populated during Deep Interview Phase (step 3)
-5. Edit to fill Section 5 (Risks & Considerations)
-6. Edit to update Status to "✅ Complete"
-
-**Edit tool pattern**:
 ```
 old_string: "## 1. Overview\n[PENDING]"
-new_string: "## 1. Overview\n\n[Your actual overview content here]"
+new_string: "## 1. Overview\n\n[Your actual content here]"
 ```
 
-**Why this approach works**:
-- ✅ Small writes/edits = no timeout risk
-- ✅ Progress is saved after each Edit call
-- ✅ Each Edit call is a single-section replacement — if one fails, all prior sections are preserved
+Sections to fill (max 50 lines each):
+1. Overview
+2. Architecture (with Contract Specifications + Before/After when applicable)
+3. Implementation Tasks (with Batch Assignment Table)
+4. Clarifications (populated during Deep Interview)
+5. Risks & Considerations
 
-**Anti-pattern that CAUSES timeouts**:
-- ❌ Writing entire plan (200+ lines) in one Write call
-- ❌ Trying to fill multiple sections in one Edit call
+Then update Status to `✅ Complete`.
 
-**Notes**
-You may include short code snippets to illustrate specific patterns, signatures, or structures, but do not implement the full solution.
+Include short code snippets to illustrate patterns, signatures, or structures — but do NOT implement full solutions. Include a Testing section identifying which unit and integration tests are needed (specify what should be tested and why; don't write the test code).
 
-Include a Testing section that identifies which unit tests and integration tests are needed. Do not write the test code — only specify what should be tested and why. Exclude deployment considerations unless they directly impact the architecture.
+## Persistence
 
-Please proceed with your analysis based on the change name provided in the {change-name} argument.
+Save the plan artifact and any general-knowledge discoveries (architecture decisions, conventions) per `_shared/persistence-contract.md` (Phase Artifact Save Convention + General Knowledge Persistence Mandate). For this phase, `title`/`topic_key` is `sdd/{change}/plan`.
 
----
+## Return Envelope
 
-## Engram Persistence (Optional — Complementary to .sdd/ Files)
+Return the SDD Envelope as your **last** output (format: `_shared/envelope-contract.md`). Nothing may follow it.
 
-After writing plan.md, persist the full plan to engram if available.
+| Field            | Value                                                                                                        |
+|------------------|--------------------------------------------------------------------------------------------------------------|
+| Status           | `ok` (plan complete, all sections filled, interview done) · `guidance_requested` (advisor consultation needed; include `requested_advisors` + `guidance_context` fields) |
+| Phase            | `plan`                                                                                                       |
+| Change           | `{change-name}`                                                                                              |
+| Artifacts        | `.sdd/{change-name}/plan.md`                                                                                 |
+| Next Recommended | `/sdd-implement {change-name}`                                                                               |
+| Risks            | Carry forward any risks from the plan's Risks & Considerations section                                       |
+| Engram Ref       | Observation ID from the persistence step, or omit if engram unavailable                                      |
 
-**Availability guard**: If engram tools are available (`mem_save` exists as a callable tool), execute the save below. If engram tools are NOT available, skip silently — do NOT error, do NOT warn the user, do NOT let engram unavailability block the workflow.
+Do NOT invoke `sdd-implement` or any other SDD skill — return the envelope; the orchestrator decides next steps.
 
-Save the plan:
+## Self-Check (before returning the envelope)
 
-mem_save(
-title: "sdd/{change-name}/plan",
-topic_key: "sdd/{change-name}/plan",
-type: "architecture",
-project: "{project-name from context}",
-content: "{full plan.md content}"
-)
-
-If engram tools are NOT available, skip this step silently. Do NOT error or warn the user. The `.sdd/` files are always the primary source of truth; engram is complementary and optional.
-
-Note the observation ID returned by `mem_save` — include it as `engram_ref` in your envelope if available.
-
----
-
-## General Knowledge Persistence (Optional — When Engram Available)
-
-Beyond the SDD phase artifact above, if you made important decisions or discoveries during planning that would benefit future sessions, save them to engram:
-
-- Architecture decisions made (e.g., chose pattern X over Y because...)
-- Risk mitigations identified
-- Codebase conventions or constraints discovered
-- Design trade-offs resolved
-
-For each:
-
-```
-mem_save(
-  title: "{short searchable description}",
-  type: "{decision|discovery|architecture}",
-  project: "{project-name}",
-  content: "**What**: {description}\n**Why**: {reasoning}\n**Where**: {files affected}\n**Learned**: {gotchas or edge cases}"
-)
-```
-
-If engram tools are NOT available, skip silently.
-
----
-
-## Return Envelope (MANDATORY)
-
-After completing the plan and updating the status to "Complete", your **LAST output** MUST be the SDD Envelope.
-
-See [envelope contract](../_shared/envelope-contract.md) for format.
-
-**Phase-specific guidance:**
-- **Status**: `ok` — plan completed with all sections filled and interview done; OR `guidance_requested` — plan draft complete but advisor consultation needed (include `requested_advisors` and `guidance_context` fields)
-- **Phase**: `plan`
-- **Change**: use the `{change-name}` from this session
-- **Artifacts**: include the plan file path `.sdd/{change-name}/plan.md`
-- **Engram Ref**: If you persisted to engram in the previous step, include the observation ID as `engram_ref` in the envelope table. Omit if engram was not used.
-- **Next Recommended**: `/sdd-implement {change-name}`
-- **Risks**: carry forward any risks identified during planning (from the Risks & Considerations section)
-
-**Rules:**
-1. The envelope is your FINAL output. Nothing after it.
-2. Do NOT invoke `sdd-implement` or any other SDD skill. Return the envelope; the orchestrator decides next steps.
-
----
-
-## Success Criteria
-
-✅ **Exploration file read** — gathered all context from `.sdd/{change-name}/exploration.md`
-✅ **Plan file created** — using the plan_template.md structure
-✅ **Deep interview completed** — minimum 2 rounds of AskUserQuestion, relevant dimensions explored
-✅ **All sections filled** — no [PENDING] placeholders remain
-✅ **Clarifications recorded** — all interview responses documented in ## 4. Clarifications with dimension labels
-✅ **Tasks follow strict format** — every task uses `- [ ] TXXX Description — file_path` format (machine-parsed by sdd-implement)
-✅ **Architecture decisions documented** — trade-offs and reasoning included
-✅ **Status updated** — marked as "✅ Complete"
-✅ **Envelope returned with correct fields** — SDD Envelope is the last output with status, phase, artifacts, next_recommended, and risks
-✅ **Detail Blocks present** — every non-trivial task has a `**Details for TXXX**:` block with signatures, types, or schema
-✅ **Contract Specifications populated** — Section 2 includes contract specs when new types/interfaces are introduced (or explicitly marked N/A)
-✅ **Before/After documented** — modification tasks show current → proposed state in Section 2
-✅ **Testable checkpoints** — every phase checkpoint lists specific verification criteria
-
-## Gotchas
-
-- **Breaking task format** — every task MUST use `- [ ] TXXX Description — file_path`. Missing IDs or non-standard formats break `sdd-implement` parsing and session resumption. Validate each task line before finalizing.
-- **Using lowercase `[x]` instead of uppercase `[X]`** — the implement phase parser only recognizes uppercase `[X]` as complete. A lowercase `[x]` will be treated as an incomplete task, causing the implement agent to re-execute already-done work.
-- **Writing the entire plan in one Write call** — large single-call writes cause timeout or permission hook failures. Use incremental Edit calls, one section per Edit; each section stays under 50 lines.
-- **Empty Contract Specifications when new types are introduced** — if the plan adds new interfaces, types, or schemas, Section 2 must list them with exact signatures. Omitting forces the implementer to invent definitions during coding.
-- **Skipping the Deep Interview Phase** — minimum 2 rounds of `AskUserQuestion` before architecture analysis is mandatory. Single-round or skipped interviews produce plans that miss hidden constraints and force design decisions during implementation.
-
-## Anti-patterns to Avoid
-
-- 🚫 **Not reading exploration.md first** — this contains critical context from discovery
-- 🚫 **Skipping the interview** — Deep Interview Phase is mandatory before architecture analysis
-- 🚫 **Asking obvious questions** — every question must pass the non-obvious filter (not answerable from exploration.md, exposes hidden decisions, challenges assumptions)
-- 🚫 **Single round of questions** — minimum 2 rounds; the interview is iterative, not one-shot
-- 🚫 **Assuming requirements** — conduct Deep Interview Phase before making architectural decisions
-- 🚫 **Breaking task format** — every task MUST use `- [ ] TXXX Description — file_path`; missing IDs, lowercase `[x]`, or non-standard formats break sdd-implement parsing and session resumption
-- 🚫 **Vague or generic tasks** — each task must specify exact files AND include a Detail Block with type signatures, function prototypes, schema definitions, or config values. A task like 'Create domain entity — src/Entity.java' without specifying fields, types, and validation rules is vague.
-- 🚫 **One-line tasks without Detail Blocks** — non-trivial tasks (creating types, implementing logic, writing tests) MUST have a Detail Block with signatures, schemas, or verification criteria. One-line descriptions force the implementer to design during coding.
-- 🚫 **Missing Before/After for modification tasks** — any task that modifies existing code MUST include before/after state in Section 2's Before/After Analysis. The implementer cannot reverse-engineer the current state from a one-line description.
-- 🚫 **Empty Contract Specifications** — when the plan introduces new types, interfaces, or data schemas, the Contract Specifications subsection in Section 2 MUST list them with exact signatures. Omitting this forces the implementer to invent type definitions.
-- 🚫 **Writing entire plan in one operation** — use incremental Edit calls
-- 🚫 **Skipping guidance request** — always request advisor guidance when the plan has cross-layer complexity or architectural uncertainty
-- 🚫 **Not integrating guidance** — when re-entered with a GUIDANCE block, always integrate applicable advisor recommendations into the plan before returning ok
-- 🚫 **Proposing implementation code** — plan describes WHAT to build (including type signatures, schemas, and interface contracts) but does NOT include full function implementations. Short code snippets showing signatures and structure are expected; complete method bodies are not
-- 🚫 **Ignoring risks section** — always document potential issues and mitigations
-- 🚫 **Omitting test scope from the plan** — always identify required unit and integration tests, even if test code is written in a later phase
-- 🚫 **Leaving [PENDING] placeholders unfilled** — every section must have real content before status is marked Complete
-- 🚫 **Invoking next skill instead of returning envelope** — never call `Skill("sdd-implement")` or any SDD skill; return the envelope and let the orchestrator decide
-- 🚫 **Adding text after the envelope** — the SDD Envelope must be the absolute last output
-- 🚫 **Defining parallelism anywhere other than the Batch table** — do not use `[P]` markers or inline parallelism hints in tasks; the Batch Assignment Table is the single source of truth
-- 🚫 **Missing Batch Assignment Table** — every plan MUST include the batch table after all tasks are defined, even when all execution is sequential
-- 🚫 **Parallel batches with undeclared cross-dependencies** — if batch B depends on batch A's output, it must declare `Depends on: A`
+- `exploration.md` was read; the plan extends/refines it instead of duplicating.
+- All template sections are filled — no `[PENDING]` placeholders remain. Status is `✅ Complete`.
+- Deep Interview ran (or was explicitly skipped with the `≤3 files` rationale recorded in `## 4. Clarifications`); responses use the `[Dimension]` format.
+- Every task uses the strict `- [ ] TXXX Description — file_path` format with uppercase `[X]` semantics.
+- Every non-trivial task has a `**Details for TXXX**:` block. Section 2 has populated Contract Specifications when new types/interfaces/schemas exist; Before/After Analysis when modifying existing code.
+- Every phase Checkpoint lists specific verifiable criteria — not "story complete".
+- The Batch Assignment Table is the single source of truth for parallelism (no inline `[P]` markers in tasks). Parallel batches declare cross-dependencies via `Depends on:`.
+- File was written incrementally via `Edit` per section — no >50-line single calls.
+- If Team Selection chose advisors, the envelope is `status: guidance_requested` (unless this is a guidance re-entry).
+- Did not invoke `sdd-implement` or any SDD phase skill; did not write code outside `.sdd/{change-name}/`.
 
 ## References
 
-Related SDD workflow skills:
-- [sdd-explore](../sdd-explore/SKILL.md) — previous phase: discovery and file curation
-- [sdd-implement](../sdd-implement/SKILL.md) — next phase: implements the plan
-- [sdd-review](../sdd-review/SKILL.md) — review changes against the plan
+Related SDD workflow skills: [sdd-explore](../sdd-explore/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Specialist skills for planning advice: see the table in step 5 above. Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md). Methodology: [interview_guide.md](references/interview_guide.md).
 
-Related specialist skills (for advisor subagent invocation):
-- See the **Specialist Skills for Planning Advice** table in step 5 above for the currently installed advisor skills
-
-Shared contracts:
-- [Persistence Contract](../_shared/persistence-contract.md) — shared persistence rules for SDD skills
-
-</meta prompt 1>
 <user_instructions>
 
 - $ARGUMENTS
 
 - change_name: $1
 - instructions: $2
-  </user_instructions>
+</user_instructions>

--- a/workflows/sdd/sdd-review/SKILL.md
+++ b/workflows/sdd/sdd-review/SKILL.md
@@ -6,9 +6,6 @@ disable-model-invocation: false
 allowed-tools: Bash(git:*), Bash(pwd), Bash(find:*), Read, Write, Glob, Grep, AskUserQuestion, Skill
 ---
 
-<meta prompt 1 = "[Review]">
-You are reviewing code changes with git diffs. Focus on ensuring changes are sound, clean, intentional, and void of regressions.
-
 ## Dynamic Context (pre-resolved)
 
 - **CWD**: !`pwd`
@@ -85,19 +82,7 @@ The git status, diff, and log were resolved in **Step 0** using `git -C <target_
 - Read `.sdd/{change-name}/plan.md` to understand expected changes
 - Read `.sdd/{change-name}/exploration.md` for additional context if needed
 
-**Engram Recovery Fallback (Two-Step — MANDATORY)**: If `plan.md` is not found and engram tools are available, use the two-step recovery pattern. **NEVER** use `mem_search` results directly — previews are truncated (~300 chars) and incomplete.
-
-```
-Step 1: Search (returns truncated preview — NOT usable as content)
-  mem_search(query: "sdd/{change-name}/plan", project: "{project}")
-  → Returns observation ID + truncated preview
-
-Step 2: Get full content (REQUIRED)
-  mem_get_observation(id: {observation-id from step 1})
-  → Returns complete, untruncated plan content
-```
-
-Use the full content from Step 2 as the plan context for your review. If neither file nor engram has the plan, proceed in standalone mode (git diff only).
+If `plan.md` is not on disk, fall back to engram via the two-step recovery pattern in `_shared/persistence-contract.md`. If neither file nor engram has the plan, proceed in standalone mode (git diff only).
 
 **Optional build verification:** If the diff includes changes to build configuration, dependency files, or structural code, run the project's build command (e.g., `make build`, `mvn compile`, `npm run build`, `go build ./...`) to verify the build still passes before reporting. This catches compilation errors that git diff alone cannot surface.
 
@@ -149,112 +134,39 @@ Format your review as:
 5. **What's Done Well** — Acknowledge good practices
 6. **Actionable Next Steps** — Specific recommendations
 
-## Engram Persistence (Optional — Complementary to .sdd/ Files)
+## Persistence
 
-After completing your review, persist the review report to engram if tools are available.
+Save the review-report artifact and any general-knowledge discoveries per `_shared/persistence-contract.md` (Phase Artifact Save Convention + General Knowledge Persistence Mandate). For this phase, `title`/`topic_key` is `sdd/{change}/review-report`.
 
-**Availability guard**: If engram tools are available (`mem_save` exists as a callable tool), execute the save below. If engram tools are NOT available, skip silently — do NOT error, do NOT warn the user, do NOT let engram unavailability block the workflow.
+## Return Envelope
 
-```
-mem_save(
-  title: "sdd/{change-name}/review-report",
-  topic_key: "sdd/{change-name}/review-report",
-  type: "architecture",
-  project: "{project-name from context}",
-  content: "# Review Report: {change-name}\n\n## Summary\n{your review summary}\n\n## Plan Alignment\n{tasks completed vs pending}\n\n## Critical Issues\n{list or 'None'}\n\n## Minor Improvements\n{list or 'None'}\n\n## Status\n{ok/warning/failed}"
-)
-```
+Return the SDD Envelope as your **last** output (format: `_shared/envelope-contract.md`). Nothing may follow it.
 
-Note the observation ID returned by `mem_save` — include it as `engram_ref` in your envelope if available.
+| Field            | Value                                                                                          |
+|------------------|------------------------------------------------------------------------------------------------|
+| Status           | `ok` (no critical issues) · `warning` (only minor) · `failed` (critical issues)                |
+| Phase            | `review`                                                                                       |
+| Artifacts        | _(none — review produces no file artifacts)_                                                   |
+| Next Recommended | `commit` if `ok`/`warning`; `fix` if `failed`                                                  |
+| Risks            | List critical findings, or "None"                                                              |
+| Engram Ref       | Observation ID from the persistence step, or omit if engram unavailable                        |
 
-## General Knowledge Persistence (Optional — When Engram Available)
+Do **not** invoke any other SDD skill or `git commit` directly — return the envelope; the orchestrator decides what runs next.
 
-Beyond the SDD phase artifact above, if you discovered important knowledge during review that would benefit future sessions, save it to engram:
+## Self-Check (before returning the envelope)
 
-- Code quality patterns or anti-patterns identified
-- Architecture improvements suggested
-- Testing gaps or coverage insights
-- Recurring issues or technical debt spotted
-
-For each:
-```
-mem_save(
-  title: "{short searchable description}",
-  type: "{discovery|pattern|decision}",
-  project: "{project-name}",
-  content: "**What**: {description}\n**Why**: {reasoning}\n**Where**: {files affected}\n**Learned**: {gotchas or edge cases}"
-)
-```
-
-If engram tools are NOT available, skip silently.
-
-### Return Envelope (MANDATORY)
-
-After completing the review, return the SDD Envelope as your **LAST output**. See [envelope contract](../_shared/envelope-contract.md) for format.
-
-**Phase-specific guidance:**
-
-| Field | Value |
-|-------|-------|
-| **Status** | `ok` — no critical issues found |
-| | `warning` — only minor issues found |
-| | `failed` — critical issues found |
-| **Phase** | `review` |
-| **Artifacts** | _(none — review produces no file artifacts)_ |
-| **Next Recommended** | `commit` if status is ok or warning; `fix` if status is failed |
-| **Risks** | List critical findings, or "None" |
-| **Engram Ref** | If you persisted to engram in the previous step, include the observation ID as `engram_ref` in the envelope table. Omit if engram was not used. |
-
-Your **LAST output MUST be the SDD Envelope**. Nothing may follow the envelope.
-
-**Rules:**
-1. The envelope is your FINAL output. Nothing after it.
-2. Do NOT invoke any other SDD skill (via Skill tool or by reading another SKILL.md). Return the envelope; the orchestrator decides next steps.
-
----
-
-## Success Criteria
-
-✅ **Git status checked** — understand scope of changes
-✅ **Git diff analyzed** — reviewed all modifications
-✅ **Plan compared** (SDD mode) — verified implementation matches plan
-✅ **Issues identified** — flagged any critical or minor concerns
-✅ **Review formatted** — clear summary with actionable items
-✅ **Envelope returned with status reflecting findings severity** — ok/warning/failed maps to finding types
-
-## Gotchas
-
-- **Reporting Critical Issues without specialist diagnosis** — before finalizing any Critical Issue, check for available `*-advisor` skills and invoke the relevant one via the Skill tool. Reporting domain logic or test coverage gaps without advisor input produces vague, unactionable feedback.
-- **Re-running git commands when Step 0 already resolved them** — Step 0 stashes git status, diff stat, full diff, and recent log via `git -C <target_path>`. Use those values directly; re-executing git commands wastes turns and may produce stale results if the working tree changes mid-review.
-- **Blocking on minor issues** — distinguish Critical (must fix before commit) from Minor (nice-to-have). Marking minor issues as blockers stalls workflow unnecessarily.
-- **Making code changes during review** — the review phase analyzes only; never modifies files. Any fixes belong in a follow-up implementation task.
-
-## Anti-patterns to Avoid
-
-- 🚫 **Skipping git diff** — always review the actual changes
-- 🚫 **Not reading plan.md** (SDD mode) — this is critical for alignment check
-- 🚫 **Vague feedback** — provide specific, actionable recommendations
-- 🚫 **Blocking on minor issues** — distinguish critical from nice-to-have
-- 🚫 **Making code changes** — review only analyzes, never modifies
-- 🚫 **Reporting Critical Issues without specialist diagnosis** — if the issue touches domain logic or test patterns, check for available advisor skills (matching `*-advisor` pattern) and invoke the relevant one before finalising the report
-- 🚫 **Invoking git:commit or other flow skills directly** — return the envelope; the orchestrator decides what runs next
-- 🚫 **Using legacy .spec references** — all context lives in `.sdd/{change-name}/`
+- Step 0 git context (status, diff stat, full diff, log) used directly — not re-executed.
+- (SDD mode) `plan.md` was read and the implementation was compared against its tasks.
+- Critical Issues that touch domain logic, architecture, or test coverage gaps include an advisor-skill diagnosis (`*-advisor`) — vague verdicts are not Critical Issues.
+- Minor improvements are listed separately; they do not block.
+- No file edits made during review — review analyzes only.
+- Envelope status reflects the severity of findings (`failed` only when something must block commit).
 
 ## References
 
-Related SDD workflow skills:
-- [sdd-explore](../sdd-explore/SKILL.md) — discovery phase
-- [sdd-plan](../sdd-plan/SKILL.md) — planning phase (plan.md used for alignment check)
-- [sdd-implement](../sdd-implement/SKILL.md) — implementation phase
+Related SDD workflow skills: [sdd-explore](../sdd-explore/SKILL.md), [sdd-plan](../sdd-plan/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md). Specialist skills: any installed `*-advisor`. Shared contracts: [envelope-contract](../_shared/envelope-contract.md), [persistence-contract](../_shared/persistence-contract.md).
 
-Related specialist skills (auto-invoked for Critical Issues):
-- Any installed advisor skills matching `*-advisor` pattern (e.g., `architect-advisor`, `unit-test-advisor`, etc.) -- discovered dynamically from the skills directory
-
-Shared contracts:
-- [envelope-contract](../_shared/envelope-contract.md) — standard SDD envelope format
-- [Persistence Contract](../_shared/persistence-contract.md) — shared persistence rules for SDD skills
-</meta prompt 1>
 <user_instructions>
 
 - change_name: $1 (optional - if provided, loads .sdd/{change-name}/plan.md context for plan alignment)
-  </user_instructions>
+</user_instructions>


### PR DESCRIPTION
Second PR from the audit umbrella in #33. Closes M3 (consolidate persistence), M4 (collapse Self-Check), and M6 (drop role preambles).

Companion regression test (#34's M9): davidarce/DevRune#59 — when this lands, that test still passes (the role invariant block remains intact at the top of every ORCHESTRATOR variant; phase SKILL.md files are not subject to the test).

## Why

The audit (#33 finding B) identified ~378 of 1.220 phase SKILL.md lines (≈30%) as restatements of content already canonical in `_shared/persistence-contract.md` and `_shared/envelope-contract.md`. Three checklists (`Success Criteria` / `Gotchas` / `Anti-patterns`) rephrased the same constraints three different ways in every phase file. The role preambles (`<meta prompt 1 = "System: …"> You are the X agent…`) duplicated information the orchestrator already conveys via `subagent_type`.

Every phase invocation paid this cost. Long workflows therefore drain context faster, which makes compaction more frequent — the second-order cause of the post-compaction role-loss reported in #33.

## What changes (uniform across the 4 phase SKILL.md)

- **M3 · Engram + General Knowledge sections collapsed**. Each phase replaces `## Engram Persistence (Optional — Complementary to .sdd/ Files)` and `## General Knowledge Persistence (Optional — When Engram Available)` with a one-line cross-reference to `_shared/persistence-contract.md`, plus the per-phase `title`/`topic_key` (e.g. `sdd/{change}/explore`).
- **M4 · Self-Check**. The three checklists (`Success Criteria` ✅ / `Gotchas` / `Anti-patterns to Avoid` 🚫) collapse into a single `## Self-Check (before returning the envelope)` block. Generic SDD rules already in `envelope-contract.md` (e.g. "envelope is your last output") are dropped — they don't need to live in every phase file.
- **M6 · Role preambles dropped**. Removed `<meta prompt 1 = "System: …">` blocks ("You are the Discover agent…", "You are a senior software architect…", "You are an autonomous agent…", "You are reviewing code changes…"). Confirmed via grep that no other catalog skill uses these tags — they were SDD-only decoration.

Phase-specific logic is preserved in full: Crit + Guidance re-entry paths, Deep Interview methodology and the 10-dimension reference, Team Selection / `<!-- ADVISOR_TABLE_PLACEHOLDER -->`, Detail Quality Gate, Batch Assignment Table format and rules, per-batch Quality Gate, Large File Creation strategy, the workspace-aware Step 0 in `sdd-review`, the incremental writing pattern for `exploration.md`/`plan.md`, and the Handoff Contract headings. **The strip removes restatements, not signal.**

## Counterpart in `_shared/persistence-contract.md`

Adds `## Phase Artifact Save Convention` — a single table giving the per-phase `title`/`topic_key` and content summary, plus the common `mem_save(...)` arguments. Phase SKILL.md files reference this instead of inlining the same `mem_save` block four times with minor variations.

## Net effect

| File                                  | before | after | Δ      |
|---------------------------------------|-------:|------:|-------:|
| `workflows/sdd/sdd-explore/SKILL.md`         |    277 |   127 | **-150** |
| `workflows/sdd/sdd-plan/SKILL.md`            |    365 |   200 | **-165** |
| `workflows/sdd/sdd-implement/SKILL.md`       |    316 |   131 | **-185** |
| `workflows/sdd/sdd-review/SKILL.md`          |    260 |   172 |  **-88** |
| `workflows/sdd/_shared/persistence-contract.md` | 232 | 257 | +25 |
| **total (5 files)**                          | **1450** | **887** | **-563** |

5 files, +320/-883.

## Test plan

- [ ] After this lands, run an SDD workflow end-to-end on Claude and OpenCode. Verify the orchestrator and each phase still execute correctly with the new instructions (the goal of the slim is to keep the workflow identical, just with less context drain).
- [ ] Check that:
  - `[ ]` → `[X]` task tracking still works in `sdd-implement` (parser semantics unchanged — just the docs are shorter).
  - The Batch Assignment Table is still parsed correctly.
  - `<!-- ADVISOR_TABLE_PLACEHOLDER -->` in `sdd-plan` is still substituted by DevRune's renderer (placeholder text unchanged, position unchanged).
- [ ] DevRune's existing renderer tests should still pass — `go test ./internal/materialize/...`. None of those tests assert specific phase SKILL.md text, so the strip should be transparent. Confirm during PR review.

## Out of scope (still pending from #33)

- M5 — move WAVE-SCOPE / QUALITY GATE / PERSISTENCE / ENVELOPE blocks out of `_shared/launch-templates.*.md` into `_shared/operational-contract.md`. Separate PR.
- M7 — move legacy/conditional content (Multi-Root Hygiene, File Slices doctrine, Crit Re-entry detail) into `references/`. Optional cleanup PR.
- M8 — drop the double `!`-mkdir in `sdd-orchestrator/SKILL.md` (canonical creation now in REGISTRY.md after #31). Tiny PR.