### PR TITLE
refactor(sdd): slim launch templates — keep dynamic context only (M5)

### DIFF
--- a/workflows/sdd/_shared/advisor-templates.md
+++ b/workflows/sdd/_shared/advisor-templates.md
@@ -157,10 +157,5 @@ Task(
   2. If it applies: update the relevant task, add/modify Detail Block, adjust Before/After, or add a new task
   3. Document integration in ## Advice Received section
   Skip the Deep Interview, Team Selection, and Guidance Request steps (already completed).
-  Re-run the Detail Quality Gate.
-  Return the SDD Envelope with status: ok (or warning if recommendations could not be fully integrated).
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-
-  IMPORTANT: Your LAST output MUST be the SDD Envelope per _shared/envelope-contract.md.'
+  Re-run the Detail Quality Gate.'
 )

--- a/workflows/sdd/_shared/launch-templates.claude.md
+++ b/workflows/sdd/_shared/launch-templates.claude.md
@@ -1,12 +1,6 @@
 # SDD Launch Templates
 
-<!-- SYNC WITH: launch-templates.copilot.md, launch-templates.opencode.md, launch-templates.md
-     When editing invocation syntax or template structure, apply equivalent changes to the
-     other variant files. The operational contract (persistence, envelope, wave-scope, quality
-     gate) lives in each phase's SKILL.md and in _shared/{persistence,envelope}-contract.md —
-     not in launch prompts. Launch prompts carry dynamic context only. -->
-
-Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase (persistence, envelope format, wave-scope discipline, quality gate, large-file rules) lives in `sdd-{phase}/SKILL.md` and the shared contracts (`_shared/persistence-contract.md`, `_shared/envelope-contract.md`). Sub-agents auto-load their assigned skill via the `skills:` frontmatter in the agent file (e.g. `sdd-planner.md` has `skills: [sdd-plan]`); no skill-load directive is needed in the prompt.
+<!-- SYNC WITH: launch-templates.copilot.md, launch-templates.opencode.md, launch-templates.md -->
 
 ## Generic Sub-Agent Template
 
@@ -69,9 +63,7 @@ Agent(
   description: 'implement batch {batch-id} for {change-name}',
   subagent_type: 'sdd-implementer',
   run_in_background: true,
-  prompt: 'BACKGROUND MODE: you cannot interact with the user (no AskUserQuestion). Write all output to {project path}/.sdd/{change-name}/ files — they are the primary communication channel.
-
-  CONTEXT:
+  prompt: 'CONTEXT:
   - Project: {project path}
   - Change: {change-name}
   - Artifact directory: {project path}/.sdd/{change-name}/

--- a/workflows/sdd/_shared/launch-templates.claude.md
+++ b/workflows/sdd/_shared/launch-templates.claude.md
@@ -1,17 +1,15 @@
 # SDD Launch Templates
 
-<!-- SYNC WITH: launch-templates.copilot.md, launch-templates.opencode.md
-     When editing invocation syntax, contract sections (WAVE-SCOPE, QUALITY GATE,
-     PERSISTENCE, ENVELOPE), or template structure in this file, apply equivalent
-     changes to the other two variant files listed above. Each file targets a
-     different invocation mechanism (Agent() / @agent-name / Task()) but carries
-     the same operational contract. -->
+<!-- SYNC WITH: launch-templates.copilot.md, launch-templates.opencode.md, launch-templates.md
+     When editing invocation syntax or template structure, apply equivalent changes to the
+     other variant files. The operational contract (persistence, envelope, wave-scope, quality
+     gate) lives in each phase's SKILL.md and in _shared/{persistence,envelope}-contract.md —
+     not in launch prompts. Launch prompts carry dynamic context only. -->
+
+Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase (persistence, envelope format, wave-scope discipline, quality gate, large-file rules) lives in `sdd-{phase}/SKILL.md` and the shared contracts (`_shared/persistence-contract.md`, `_shared/envelope-contract.md`). Sub-agents auto-load their assigned skill via the `skills:` frontmatter in the agent file (e.g. `sdd-planner.md` has `skills: [sdd-plan]`); no skill-load directive is needed in the prompt.
 
 ## Generic Sub-Agent Template
 
-All SDD phases use this template. Replace `{phase}` with explore/plan/implement/review.
-
-Subagent type mapping per phase:
 | Phase | Subagent Type |
 |-------|---------------|
 | explore | `sdd-explorer` |
@@ -31,29 +29,15 @@ Agent(
   - Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
   TASK:
-  {specific task description}
-
-  PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-  - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  {specific task description}'
 )
 ```
-
-> **Claude note**: Sub-agents auto-load their assigned skill via the `skills:` frontmatter in their
-> agent file (e.g. `sdd-planner.md` has `skills: [sdd-plan]`). The prompt above carries ONLY the
-> dynamic context — no Skill-load directive is needed or should be added.
 
 ---
 
 ## Implement Phase: Sequential Batch Template (foreground)
 
-The implement phase is special: the orchestrator reads plan.md and launches one sub-agent per batch
-or wave. Use this template for `Parallel=No` batches or when a batch has dependencies on other
-batches in the same wave.
+For `Parallel=No` batches, or batches that depend on other batches in the same wave.
 
 ```
 Agent(
@@ -67,29 +51,10 @@ Agent(
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
-  Implement ONLY the following batches from this wave:
+  Implement ONLY these batches from this wave:
   {paste batch table rows for this wave only}
 
-  Previously completed batches: {list of completed batch IDs}
-
-  WAVE-SCOPE DISCIPLINE:
-  - Implement ONLY the listed batches above.
-  - Do NOT infer additional batches from the Batch Assignment Table.
-  - Do NOT launch Agent()/Task() calls to implement other batches — orchestrator manages progression.
-  - Mark ONLY listed batch tasks as [X] in plan.md IMMEDIATELY after each task.
-  - Return envelope with status reflecting THIS wave only.
-
-  QUALITY GATE (per-batch):
-  After the LAST task of each batch: read the Phase Checkpoint block from plan.md that covers
-  this batch phase. Run each checkpoint bullet as a verifiable command (build/test/lint).
-  If any checkpoint fails: STOP, return envelope with status: failed.
-
-  PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  Previously completed batches: {list of completed batch IDs}'
 )
 ```
 
@@ -97,52 +62,26 @@ Agent(
 
 ## Implement Phase: Parallel Batch Template (background)
 
-Use this template for `Parallel=Yes` batches with no cross-dependencies within the wave. Launch all
-such batches simultaneously using multiple Agent() calls in a single message.
-
-The orchestrator waits for all background agents to complete via notification before running the
-Post-Phase Protocol.
+For `Parallel=Yes` batches with no cross-dependencies. Launch all such batches simultaneously via multiple `Agent()` calls in a single message.
 
 ```
 Agent(
   description: 'implement batch {batch-id} for {change-name}',
   subagent_type: 'sdd-implementer',
   run_in_background: true,
-  prompt: 'CONTEXT:
+  prompt: 'BACKGROUND MODE: you cannot interact with the user (no AskUserQuestion). Write all output to {project path}/.sdd/{change-name}/ files — they are the primary communication channel.
+
+  CONTEXT:
   - Project: {project path}
   - Change: {change-name}
   - Artifact directory: {project path}/.sdd/{change-name}/
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
-  Implement ONLY the following batch from this wave:
+  Implement ONLY this batch from the wave:
   {paste batch table rows for this batch only}
 
-  Previously completed batches: {list of completed batch IDs}
-
-  WAVE-SCOPE DISCIPLINE:
-  - Implement ONLY the listed batch above.
-  - Do NOT infer additional batches from the Batch Assignment Table.
-  - Do NOT launch Agent()/Task() calls to implement other batches — orchestrator manages progression.
-  - Mark ONLY listed batch tasks as [X] in plan.md IMMEDIATELY after each task.
-  - Return envelope with status reflecting THIS batch only.
-
-  QUALITY GATE (per-batch):
-  After the LAST task of each batch: read the Phase Checkpoint block from plan.md that covers
-  this batch phase. Run each checkpoint bullet as a verifiable command (build/test/lint).
-  If any checkpoint fails: STOP, return envelope with status: failed.
-
-  BACKGROUND MODE: You are running as a background sub-agent. You cannot interact with the user
-  (no AskUserQuestion). Write ALL output to .sdd/{change-name}/ files — these artifact files are
-  the primary communication channel. Mark completed tasks as [X] in plan.md IMMEDIATELY after
-  each task.
-
-  PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  Previously completed batches: {list of completed batch IDs}'
 )
 ```
 
@@ -150,38 +89,21 @@ Agent(
 
 ## Background Execution Guide
 
-### When to Use Background Mode
+`run_in_background: true` is allowed ONLY for `Parallel=Yes` implement batches. Every other phase and batch type must use foreground.
 
-Only use `run_in_background: true` for `Parallel=Yes` implement batches with no cross-dependencies
-within the same wave. All other phases and batch types must use foreground (`run_in_background: false`).
+| Phase | Default Mode | Background Allowed? |
+|-------|--------------|---------------------|
+| explore | foreground | No (orchestrator needs envelope for auto-transition) |
+| plan | foreground | No (Deep Interview is interactive) |
+| implement (sequential) | foreground | No (dependent or `Parallel=No`) |
+| implement (parallel) | background | Yes (`Parallel=Yes`, no cross-deps) |
+| review | foreground | No (single pass; needs envelope for fix-cycle decision) |
 
-### Default Mode Per Phase
-
-| Phase | Default Mode | Background Allowed? | Rationale |
-|-------|-------------|---------------------|-----------|
-| explore | foreground | No | Interactive: orchestrator needs envelope immediately for auto-transition to plan. Short duration. |
-| plan | foreground | No | Interactive: Deep Interview requires user Q&A. Orchestrator needs plan.md for Crit review protocol. |
-| implement (sequential batch) | foreground | No | Batch has dependencies or is Parallel=No; must complete before next batch starts. |
-| implement (parallel batch) | background | Yes | Parallel=Yes batches with no cross-dependencies benefit from concurrent execution. |
-| review | foreground | No | Single pass, needs envelope for Post-Review Fix Cycle decisions. Short duration. |
-
-### Output Capture
-
-Background Agent() returns when complete; the orchestrator reads the envelope from the Agent()
-return value (same as foreground). Sub-agents also write all artifacts to `.sdd/{change}/` files
-(plan.md markers, state files) as the primary persistence channel.
-
-### Limitation
-
-Background sub-agents cannot interact with the user (no AskUserQuestion). Only implement phase
-sub-agents using the Parallel Batch Template are safe for background execution since they do not
-require user interaction during implementation.
+Background `Agent()` returns when complete; the orchestrator reads the envelope from the return value (same as foreground). Sub-agents also write all artifacts to `.sdd/{change}/` files as the primary persistence channel.
 
 ---
 
 ## Plan Phase: Re-entry with Crit Feedback Template
-
-When the orchestrator re-enters `sdd-plan` after a Crit review round:
 
 ```
 Agent(
@@ -195,27 +117,11 @@ Agent(
   - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
   CRIT_FEEDBACK (Round {N}):
-  {formatted markdown list of unresolved comments from .crit.json}
-
-  TASK:
-  Address each comment in the CRIT_FEEDBACK block by revising plan.md.
-  Reply to each addressed comment using:
-    crit comment --plan {change-name} --reply-to {id} --author "Claude Code" "<what you did>"
-  Skip the Deep Interview and Advice Phase (already completed).
-  Re-run the Detail Quality Gate.
-
-  PERSISTENCE: See {project path}/.claude/skills/sdd-orchestrator/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-  - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  {formatted markdown list of unresolved comments from .crit.json}'
 )
 ```
 
-The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK format defined in
-the Crit Plan Review Protocol section of ORCHESTRATOR.md.
+The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK format defined in the Crit Plan Review Protocol section of ORCHESTRATOR.md.
 
 ## Initial Workflow Marker
 
@@ -231,4 +137,3 @@ mem_save(
 ```
 
 This enables compaction recovery (see `_shared/recovery.md`).
-

--- a/workflows/sdd/_shared/launch-templates.copilot.md
+++ b/workflows/sdd/_shared/launch-templates.copilot.md
@@ -1,18 +1,15 @@
 # SDD Launch Templates
 
-<!-- SYNC WITH: launch-templates.claude.md, launch-templates.opencode.md
-     When editing invocation syntax, contract sections (WAVE-SCOPE, QUALITY GATE,
-     PERSISTENCE, ENVELOPE), or template structure in this file, apply equivalent
-     changes to the other two variant files listed above. Each file targets a
-     different invocation mechanism (Agent() / @agent-name / Task()) but carries
-     the same operational contract. -->
+<!-- SYNC WITH: launch-templates.claude.md, launch-templates.opencode.md, launch-templates.md
+     When editing invocation syntax or template structure, apply equivalent changes to the
+     other variant files. The operational contract (persistence, envelope, wave-scope, quality
+     gate) lives in each phase's SKILL.md and in _shared/{persistence,envelope}-contract.md —
+     not in launch prompts. Launch prompts carry dynamic context only. -->
+
+Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase lives in the agent's `.agent.md` file (the renderer inlines the SKILL.md body) and in `_shared/persistence-contract.md` + `_shared/envelope-contract.md`. The agent file IS the system prompt; no skill-load directive is needed in the invocation prompt.
 
 ## Generic Sub-Agent Invocation
 
-All SDD phases use this template. Replace `{phase}` with explore/plan/implement/review and
-`@sdd-{phase}` with the appropriate agent name.
-
-Agent name mapping per phase:
 | Phase | Agent |
 |-------|-------|
 | explore | `@sdd-explorer` |
@@ -31,27 +28,13 @@ CONTEXT:
 
 TASK:
 {specific task description for this phase}
-
-PERSISTENCE: See {project path}/.github/instructions/sdd-orchestrator/_shared/persistence-contract.md
-- Primary: always write to {project path}/.sdd/{change-name}/
-- Engram: save summary if available, skip silently if not
-- Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-`_shared/envelope-contract.md`. Nothing may follow the envelope.
 ```
-
-> **Copilot note**: Copilot SDD-phase agent files have the full SKILL.md body inlined by the
-> renderer. The agent file IS already the system prompt — no Skill-load directive is needed or
-> should be added. The prompt above carries ONLY the dynamic context.
 
 ---
 
 ## Implement Phase: Sequential Batch Invocation
 
-Copilot does not support background execution — all batches run sequentially in foreground.
-Use this template for every implement batch regardless of the `Parallel` column in the Batch
-Assignment Table.
+Copilot does not support background execution — all batches run sequentially in foreground regardless of the `Parallel` column. The orchestrator launches one `@sdd-implementer` invocation at a time and waits for the envelope before proceeding.
 
 Invoke `@sdd-implementer` with this prompt:
 
@@ -63,50 +46,20 @@ CONTEXT:
 - Previous artifacts: exploration.md, plan.md
 
 TASK:
-Implement ONLY the following batch from this wave:
+Implement ONLY these batches from this wave:
 
 | Batch | Tasks | File | Parallel | Depends on |
 |-------|-------|------|----------|------------|
-{paste the batch row(s) for this wave only}
+{paste batch table row(s) for this wave only}
 
 Previously completed batches: {list of completed batch IDs, or "none"}
-
-WAVE-SCOPE DISCIPLINE:
-- Implement ONLY the listed batch(es) above.
-- Do NOT infer additional batches from the Batch Assignment Table.
-- Do NOT invoke other agents to implement other batches — the orchestrator manages progression.
-- Mark ONLY the listed batch tasks as [X] in plan.md IMMEDIATELY after each task.
-- Return the SDD Envelope with status reflecting THIS wave only.
-
-QUALITY GATE (per-batch):
-After the LAST task of each batch: read the Phase Checkpoint block from plan.md that covers
-this batch's phase. Run each checkpoint bullet as a verifiable command (build/test/lint/grep).
-If any checkpoint fails: STOP, return the SDD Envelope with status: failed.
-
-BACKGROUND MODE: You are running as a background sub-agent. You cannot interact with the user
-(no AskUserQuestion). Write ALL output to .sdd/{change-name}/ files — these artifact files
-are the primary communication channel. Mark completed tasks as [X] in plan.md IMMEDIATELY
-after each task.
-
-PERSISTENCE: See {project path}/.github/instructions/sdd-orchestrator/_shared/persistence-contract.md
-- Primary: always write to {project path}/.sdd/{change-name}/
-- Engram: save summary if available, skip silently if not
-
-ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-`_shared/envelope-contract.md`. Nothing may follow the envelope.
 ```
-
-> **Copilot note**: There is no parallel batch template for Copilot. Copilot does not support
-> `run_in_background`. All batches — regardless of the `Parallel` column — run sequentially.
-> The orchestrator launches one `@sdd-implementer` invocation at a time and waits for the
-> envelope before proceeding to the next batch.
 
 ---
 
 ## Advisor Invocation
 
-When consulting an advisor (architect, unit-test, integration-test, component, api-first, etc.),
-invoke `@{advisor-skill}` with this prompt:
+When consulting an advisor (architect, unit-test, integration-test, component, api-first, etc.), invoke `@{advisor-skill}` with this prompt:
 
 ```
 {advisor context — relevant code snippets, current design, specific question or concern}
@@ -123,24 +76,16 @@ Return your response in this exact format:
 {concrete, actionable suggestions — one per bullet}
 
 ### Engram Observation ID
-{the ID returned by mem_save if you persisted advice to engram; omit this section if engram
-is unavailable}
+{the ID returned by mem_save if you persisted advice to engram; omit this section if engram is unavailable}
 
-Do NOT return an SDD envelope — advisors return the structured advice format above, not an
-envelope. Persist advice via mem_save if engram is available.
+Do NOT return an SDD envelope — advisors return the structured advice format above, not an envelope. Persist advice via mem_save if engram is available.
 ```
 
-> **Copilot note**: Advisor agent files load their own SKILL.md — the orchestrator does not
-> inject the skill. The prompt above provides the question context and return-format contract.
-> Internal references within invocation prompts use `launch-templates.md` (installed name).
+> **Copilot note**: Advisor agent files load their own SKILL.md — the orchestrator does not inject the skill. The prompt above provides the question context and return-format contract.
 
 ---
 
 ## Plan Phase: Re-entry with Crit Feedback
-
-When the orchestrator re-enters `@sdd-planner` after a Crit review round:
-
-Invoke `@sdd-planner` with this prompt:
 
 ```
 CONTEXT:
@@ -152,25 +97,11 @@ CONTEXT:
 CRIT_FEEDBACK (Round {N}):
 {formatted markdown list of unresolved comments from .crit.json}
 
-TASK:
-Address each comment in the CRIT_FEEDBACK block by revising plan.md.
-Reply to each addressed comment using:
+When replying to comments, use:
   crit comment --plan {change-name} --reply-to {id} --author "Copilot" "<what you did>"
-Skip the Deep Interview and Advice Phase (already completed).
-Re-run the Detail Quality Gate.
-Return the SDD Envelope.
-
-PERSISTENCE: See {project path}/.github/instructions/sdd-orchestrator/_shared/persistence-contract.md
-- Primary: always write to {project path}/.sdd/{change-name}/
-- Engram: save summary if available, skip silently if not
-- Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-`_shared/envelope-contract.md`. Nothing may follow the envelope.
 ```
 
-The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK format defined
-in the Crit Plan Review Protocol section of `ORCHESTRATOR.copilot.md`.
+The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK format defined in the Crit Plan Review Protocol section of `ORCHESTRATOR.copilot.md`.
 
 ---
 

--- a/workflows/sdd/_shared/launch-templates.copilot.md
+++ b/workflows/sdd/_shared/launch-templates.copilot.md
@@ -1,12 +1,6 @@
 # SDD Launch Templates
 
-<!-- SYNC WITH: launch-templates.claude.md, launch-templates.opencode.md, launch-templates.md
-     When editing invocation syntax or template structure, apply equivalent changes to the
-     other variant files. The operational contract (persistence, envelope, wave-scope, quality
-     gate) lives in each phase's SKILL.md and in _shared/{persistence,envelope}-contract.md —
-     not in launch prompts. Launch prompts carry dynamic context only. -->
-
-Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase lives in the agent's `.agent.md` file (the renderer inlines the SKILL.md body) and in `_shared/persistence-contract.md` + `_shared/envelope-contract.md`. The agent file IS the system prompt; no skill-load directive is needed in the invocation prompt.
+<!-- SYNC WITH: launch-templates.claude.md, launch-templates.opencode.md, launch-templates.md -->
 
 ## Generic Sub-Agent Invocation
 

--- a/workflows/sdd/_shared/launch-templates.md
+++ b/workflows/sdd/_shared/launch-templates.md
@@ -1,11 +1,6 @@
-> **Scope**: this file is consumed by **Codex and Factory** variants only.
-> Other variants use their own launch-template files.
-
----
-
 # SDD Launch Templates
 
-Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase (persistence, envelope format, wave-scope discipline, quality gate, large-file rules) lives in the phase's `SKILL.md` and the shared contracts under `_shared/` (`persistence-contract.md`, `envelope-contract.md`). Sub-agents load `sdd-{phase}/SKILL.md` at start; the launch prompt does NOT need to repeat the contract.
+<!-- Scope: consumed by Codex and Factory variants only. Other variants use their own launch-template files. -->
 
 ## Generic Sub-Agent Template
 
@@ -86,8 +81,6 @@ Task(
   Skill(skill: "sdd-implement", args: "{change-name}")
 
   If that fails, fall back to {project path}/{SKILLS_PATH}/sdd-implement/SKILL.md.
-
-  BACKGROUND MODE: you cannot interact with the user (no AskUserQuestion). Write all output to {project path}/.sdd/{change-name}/ files — they are the primary communication channel.
 
   CONTEXT:
   - Project: {project path}

--- a/workflows/sdd/_shared/launch-templates.md
+++ b/workflows/sdd/_shared/launch-templates.md
@@ -1,15 +1,16 @@
-> **Scope**: This file is consumed by **Codex and Factory** variants only.
+> **Scope**: this file is consumed by **Codex and Factory** variants only.
 > Other variants use their own launch-template files.
 
 ---
 
 # SDD Launch Templates
 
+Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase (persistence, envelope format, wave-scope discipline, quality gate, large-file rules) lives in the phase's `SKILL.md` and the shared contracts under `_shared/` (`persistence-contract.md`, `envelope-contract.md`). Sub-agents load `sdd-{phase}/SKILL.md` at start; the launch prompt does NOT need to repeat the contract.
+
 ## Generic Sub-Agent Template
 
 All SDD phases use this template. Replace `{phase}` with explore/plan/implement/review.
 
-Subagent type mapping per phase:
 | Phase | Subagent Type |
 |-------|---------------|
 | explore | `{WORKFLOW_SUBAGENT_EXPLORER}` |
@@ -23,12 +24,11 @@ Task(
   subagent_type: '{subagent type from table above}',
   model: '{model from Phase-to-Model Table}',
   run_in_background: false,  // set true only for parallel implement batches
-  prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading your phase instructions via the Skill tool:
+  prompt: 'Load your phase instructions:
 
   Skill(skill: "sdd-{phase}", args: "{change-name}")
 
-  If the Skill tool succeeds, follow the loaded instructions for {phase}.
-  If the Skill tool fails (skill not found/not registered), fall back to reading the skill file at {project path}/{SKILLS_PATH}/sdd-{phase}/SKILL.md directly.
+  If the Skill tool fails, fall back to {project path}/{SKILLS_PATH}/sdd-{phase}/SKILL.md.
 
   CONTEXT:
   - Project: {project path}
@@ -37,20 +37,13 @@ Task(
   - Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
   TASK:
-  {specific task description}
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-  - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-  IMPORTANT: Your LAST output MUST be the SDD Envelope per _shared/envelope-contract.md.'
+  {specific task description}'
 )
 ```
 
 ## Implement Phase: Sequential Batch Template (foreground)
 
-The implement phase is special: the orchestrator reads plan.md and launches one sub-agent per batch or wave. Use this template for `Parallel=No` batches or when a batch has dependencies on other batches in the same wave.
+For `Parallel=No` batches, or batches that depend on other batches in the same wave.
 
 ```
 Task(
@@ -58,11 +51,11 @@ Task(
   subagent_type: '{WORKFLOW_SUBAGENT_IMPLEMENTER}',
   model: '{WORKFLOW_MODEL_IMPLEMENTER}',
   run_in_background: false,
-  prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading:
+  prompt: 'Load your phase instructions:
 
   Skill(skill: "sdd-implement", args: "{change-name}")
 
-  If that fails, read {project path}/{SKILLS_PATH}/sdd-implement/SKILL.md directly.
+  If that fails, fall back to {project path}/{SKILLS_PATH}/sdd-implement/SKILL.md.
 
   CONTEXT:
   - Project: {project path}
@@ -71,27 +64,16 @@ Task(
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
-  Implement ONLY the following batches from this wave:
+  Implement ONLY these batches from this wave:
   {paste batch table rows for this wave only}
 
-  Previously completed batches: {list of completed batch IDs}
-
-  After implementing each task:
-  1. Mark completed tasks as [X] in plan.md IMMEDIATELY (not at the end)
-  2. Run quality gate (build/test) per task
-  3. Return the SDD Envelope with status reflecting THIS wave only
-
-  Do NOT implement batches beyond this wave. The orchestrator manages wave progression.
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md'
+  Previously completed batches: {list of completed batch IDs}'
 )
 ```
 
 ## Implement Phase: Parallel Batch Template (background)
 
-Use this template for `Parallel=Yes` batches with no cross-dependencies within the wave. Launch all such batches simultaneously using multiple Task() calls in a single message.
-
-The orchestrator waits for all background tasks to complete via notification before running the Post-Phase Protocol.
+For `Parallel=Yes` batches with no cross-dependencies. Launch all such batches simultaneously via multiple `Task()` calls in a single message.
 
 ```
 Task(
@@ -99,11 +81,13 @@ Task(
   subagent_type: '{WORKFLOW_SUBAGENT_IMPLEMENTER}',
   model: '{WORKFLOW_MODEL_IMPLEMENTER}',
   run_in_background: true,
-  prompt: 'You are an SDD sub-agent running in background mode. Your first action MUST be to try loading:
+  prompt: 'Load your phase instructions:
 
   Skill(skill: "sdd-implement", args: "{change-name}")
 
-  If that fails, read {project path}/{SKILLS_PATH}/sdd-implement/SKILL.md directly.
+  If that fails, fall back to {project path}/{SKILLS_PATH}/sdd-implement/SKILL.md.
+
+  BACKGROUND MODE: you cannot interact with the user (no AskUserQuestion). Write all output to {project path}/.sdd/{change-name}/ files — they are the primary communication channel.
 
   CONTEXT:
   - Project: {project path}
@@ -112,70 +96,40 @@ Task(
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
-  Implement ONLY the following batches from this wave:
+  Implement ONLY this batch from the wave:
   {paste batch table rows for this batch only}
 
-  Previously completed batches: {list of completed batch IDs}
-
-  BACKGROUND MODE: You are running as a background sub-agent. You cannot interact with the user (no AskUserQuestion). Write ALL output to .sdd/{change-name}/ files — these artifact files are the primary communication channel. Mark completed tasks as [X] in plan.md IMMEDIATELY after each task.
-
-  After implementing each task:
-  1. Mark completed tasks as [X] in plan.md IMMEDIATELY (not at the end)
-  2. Run quality gate (build/test) per task
-  3. Return the SDD Envelope with status reflecting THIS batch only
-
-  Do NOT implement batches beyond this batch. The orchestrator manages wave progression.
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md'
+  Previously completed batches: {list of completed batch IDs}'
 )
 ```
 
 ## Background Execution Guide
 
-### When to Use Background Mode
+`run_in_background: true` is allowed ONLY for `Parallel=Yes` implement batches. Every other phase and batch type must use foreground.
 
-Only use `run_in_background: true` for `Parallel=Yes` implement batches with no cross-dependencies within the same wave. All other phases and batch types must use foreground (`run_in_background: false`).
+| Phase | Default Mode | Background Allowed? |
+|-------|--------------|---------------------|
+| explore | foreground | No (orchestrator needs envelope for auto-transition) |
+| plan | foreground | No (Deep Interview is interactive) |
+| implement (sequential) | foreground | No (dependent or `Parallel=No`) |
+| implement (parallel) | background | Yes (`Parallel=Yes`, no cross-deps) |
+| review | foreground | No (single pass; needs envelope for fix-cycle decision) |
 
-### Default Mode Per Phase
-
-| Phase | Default Mode | Background Allowed? | Rationale |
-|-------|-------------|---------------------|-----------|
-| explore | foreground | No | Interactive: orchestrator needs envelope immediately for auto-transition to plan. Short duration. |
-| plan | foreground | No | Interactive: Deep Interview requires user Q&A. Orchestrator needs plan.md for Crit review protocol. |
-| implement (sequential batch) | foreground | No | Batch has dependencies or is Parallel=No; must complete before next batch starts. |
-| implement (parallel batch) | background | Yes | Parallel=Yes batches with no cross-dependencies benefit from concurrent execution. |
-| review | foreground | No | Single pass, needs envelope for Post-Review Fix Cycle decisions. Short duration. |
-
-### Output Capture
-
-Background Task() returns when complete; the orchestrator reads the envelope from the Task() return value (same as foreground). Sub-agents also write all artifacts to `.sdd/{change}/` files (plan.md markers, state files) as the primary persistence channel.
-
-### Limitation
-
-Background sub-agents cannot interact with the user (no AskUserQuestion). Only implement phase sub-agents using the Parallel Batch Template are safe for background execution since they do not require user interaction during implementation.
-
-### Agent Compatibility
-
-`run_in_background` is natively supported by Claude Code. Agents that do not support background Task() execution (Codex, OpenCode, Copilot, Factory Droid) should fall back to sequential foreground execution for all batches. The `run_in_background: false` default is safe for all agents.
-
----
+`run_in_background` is natively supported by Claude Code. Codex / OpenCode / Copilot / Factory fall back to sequential foreground for all batches.
 
 ## Plan Phase: Re-entry with Crit Feedback Template
-
-When the orchestrator re-enters `sdd-plan` after a Crit review round:
 
 ```
 Task(
   description: 'plan re-entry (crit round {N}) for {change-name}',
   subagent_type: '{WORKFLOW_SUBAGENT_PLANNER}',
   model: 'opus',
-  run_in_background: false,  // plan re-entry is always foreground (interactive crit feedback loop)
-  prompt: 'You are an SDD sub-agent. Your first action MUST be to try loading your phase instructions via the Skill tool:
+  run_in_background: false,
+  prompt: 'Load your phase instructions:
 
   Skill(skill: "sdd-plan", args: "{change-name}")
 
-  If the Skill tool succeeds, follow the loaded instructions for plan.
-  If the Skill tool fails (skill not found/not registered), fall back to reading the skill file at {project path}/{SKILLS_PATH}/sdd-plan/SKILL.md directly.
+  If that fails, fall back to {project path}/{SKILLS_PATH}/sdd-plan/SKILL.md.
 
   CONTEXT:
   - Project: {project path}
@@ -184,21 +138,7 @@ Task(
   - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
 
   CRIT_FEEDBACK (Round {N}):
-  {formatted markdown list of unresolved comments from .crit.json}
-
-  TASK:
-  Address each comment in the CRIT_FEEDBACK block by revising plan.md.
-  Reply to each addressed comment using: crit comment --plan {change-name} --reply-to {id} --author "Claude Code" "<what you did>"
-  Skip the Deep Interview and Advice Phase (already completed).
-  Re-run the Detail Quality Gate.
-  Return the SDD Envelope.
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-  - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-  IMPORTANT: Your LAST output MUST be the SDD Envelope per _shared/envelope-contract.md.'
+  {formatted markdown list of unresolved comments from .crit.json}'
 )
 ```
 

--- a/workflows/sdd/_shared/launch-templates.opencode.md
+++ b/workflows/sdd/_shared/launch-templates.opencode.md
@@ -1,18 +1,7 @@
 # SDD Launch Templates
 
-<!-- SYNC WITH: launch-templates.claude.md, launch-templates.copilot.md, launch-templates.md
-     When editing invocation syntax or template structure, apply equivalent changes to the
-     other variant files. The operational contract (persistence, envelope, wave-scope, quality
-     gate) lives in each phase's SKILL.md and in _shared/{persistence,envelope}-contract.md —
-     not in launch prompts. Launch prompts carry dynamic context only. -->
-
-> **Note**: this file is consumed by the **OpenCode** variant only. The installed name is always `launch-templates.md` (devrune install strips the `.opencode.md` suffix). All internal references use `launch-templates.md`.
-
-Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase (persistence, envelope format, wave-scope discipline, quality gate, large-file rules) lives in `sdd-{phase}/SKILL.md` and the shared contracts (`_shared/persistence-contract.md`, `_shared/envelope-contract.md`).
-
-> **OpenCode note**: OpenCode agent files are 1-line prompts in `opencode.json` and have no native skill pre-loading mechanism. The "read SKILL.md first" directive at the top of every prompt is intentional and must be retained. If a future OpenCode renderer inlines SKILL.md content into the agent prompt, this directive can be dropped.
-
----
+<!-- SYNC WITH: launch-templates.claude.md, launch-templates.copilot.md, launch-templates.md -->
+<!-- OpenCode-only file. Installed name strips the .opencode.md suffix to launch-templates.md. -->
 
 ## Generic Sub-Agent Template
 

--- a/workflows/sdd/_shared/launch-templates.opencode.md
+++ b/workflows/sdd/_shared/launch-templates.opencode.md
@@ -1,23 +1,21 @@
 # SDD Launch Templates
 
-<!-- SYNC WITH: launch-templates.claude.md, launch-templates.copilot.md
-     When editing invocation syntax, contract sections (WAVE-SCOPE, QUALITY GATE,
-     PERSISTENCE, ENVELOPE), or template structure in this file, apply equivalent
-     changes to the other two variant files listed above. Each file targets a
-     different invocation mechanism (Agent() / @agent-name / Task()) but carries
-     the same operational contract. -->
+<!-- SYNC WITH: launch-templates.claude.md, launch-templates.copilot.md, launch-templates.md
+     When editing invocation syntax or template structure, apply equivalent changes to the
+     other variant files. The operational contract (persistence, envelope, wave-scope, quality
+     gate) lives in each phase's SKILL.md and in _shared/{persistence,envelope}-contract.md —
+     not in launch prompts. Launch prompts carry dynamic context only. -->
 
-> **Note**: This file is consumed by the **OpenCode** variant only.
-> The installed name is always `launch-templates.md` (devrune install strips the `.opencode.md` suffix).
-> All internal references use `launch-templates.md` — never `launch-templates.opencode.md`.
+> **Note**: this file is consumed by the **OpenCode** variant only. The installed name is always `launch-templates.md` (devrune install strips the `.opencode.md` suffix). All internal references use `launch-templates.md`.
+
+Launch prompts carry **dynamic context only** — project path, change name, artifact list, batch directive. The full operational contract for each phase (persistence, envelope format, wave-scope discipline, quality gate, large-file rules) lives in `sdd-{phase}/SKILL.md` and the shared contracts (`_shared/persistence-contract.md`, `_shared/envelope-contract.md`).
+
+> **OpenCode note**: OpenCode agent files are 1-line prompts in `opencode.json` and have no native skill pre-loading mechanism. The "read SKILL.md first" directive at the top of every prompt is intentional and must be retained. If a future OpenCode renderer inlines SKILL.md content into the agent prompt, this directive can be dropped.
 
 ---
 
 ## Generic Sub-Agent Template
 
-All SDD phases use this template. Replace `{phase}` with explore/plan/implement/review.
-
-Subagent type mapping per phase:
 | Phase | Subagent Type |
 |-------|---------------|
 | explore | `{WORKFLOW_SUBAGENT_EXPLORER}` |
@@ -38,28 +36,15 @@ Task(
   - Previous artifacts: {list of {project path}/.sdd/{change-name}/ files to read}
 
   TASK:
-  {specific task description for this phase}
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-  - Save significant discoveries/decisions/bugfixes to engram independently of phase artifacts
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `{WORKFLOW_DIR}/_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  {specific task description for this phase}'
 )
 ```
-
-> **OpenCode note**: OpenCode agent files are 1-line prompts in `opencode.json` and have no native
-> skill pre-loading mechanism. The Skill-load directive above ("read SKILL.md first") is intentional
-> and must be retained in every prompt template. If a future OpenCode renderer inlines SKILL.md
-> content into the agent prompt, this directive can be dropped at that time.
 
 ---
 
 ## Implement Phase: Sequential Batch Template (foreground)
 
-The implement phase is special: the orchestrator reads plan.md and launches one sub-agent per batch or wave. Use this template for each batch. OpenCode does not support `run_in_background` — all batches execute as foreground Task() calls, one at a time.
+OpenCode does not support `run_in_background` — all batches execute as foreground `Task()` calls, one at a time, regardless of the `Parallel` column.
 
 ```
 Task(
@@ -74,7 +59,7 @@ Task(
   - Previous artifacts: exploration.md, plan.md
 
   TASK:
-  Implement ONLY the following batch from this wave:
+  Implement ONLY this batch from the wave:
 
   | Batch | Tasks | File | Parallel | Depends on |
   |-------|-------|------|----------|------------|
@@ -82,29 +67,7 @@ Task(
 
   Read the full task detail from plan.md for each task listed above.
 
-  Previously completed batches: {list of completed batch IDs, or "none" if first wave}
-
-  After implementing each task:
-  1. Mark completed tasks as [X] in plan.md IMMEDIATELY (not at the end)
-  2. Run the Phase Checkpoint from plan.md for this batch (not a generic test suite) —
-     if any checkpoint fails, STOP and return envelope with status: failed
-  3. Return the SDD Envelope with status reflecting THIS batch only
-
-  Do NOT implement batches beyond this batch. The orchestrator manages wave progression.
-
-  WAVE-SCOPE DISCIPLINE: Your scope is the batch listed above. Do NOT read ahead, infer,
-  or launch additional Task() calls for other batches. The orchestrator owns progression.
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-
-  QUALITY GATE: After the LAST task of each batch, run the Phase Checkpoint criteria
-  from plan.md (the Checkpoint block for this batch). Stop and return failed if any
-  checkpoint criterion fails.
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `{WORKFLOW_DIR}/_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  Previously completed batches: {list of completed batch IDs, or "none" if first wave}'
 )
 ```
 
@@ -112,22 +75,11 @@ Task(
 
 ## Implement Phase: Parallel Batches (foreground-only for OpenCode)
 
-> **OpenCode limitation**: OpenCode does not support `run_in_background`. There is no parallel
-> batch template for OpenCode. When the Batch Assignment Table contains `Parallel=Yes` batches,
-> execute them sequentially as foreground Task() calls — one at a time — using the Sequential
-> Batch Template above.
->
-> Concretely: launch batch A (foreground), wait for completion, launch batch B (foreground),
-> wait for completion, etc. Do NOT attempt to launch multiple Task() calls simultaneously.
-
-For each `Parallel=Yes` batch, use the Sequential Batch Template above with the single batch row.
-Update `Previously completed batches:` before each launch.
+> **OpenCode limitation**: OpenCode does not support `run_in_background`. There is no parallel batch template. When the Batch Assignment Table contains `Parallel=Yes` batches, execute them sequentially as foreground `Task()` calls — one at a time — using the Sequential Batch Template above. Update `Previously completed batches:` before each launch.
 
 ---
 
 ## Plan Phase: Re-entry with Crit Feedback Template
-
-When the orchestrator re-enters `sdd-plan` after a Crit review round:
 
 ```
 Task(
@@ -144,24 +96,12 @@ Task(
   CRIT_FEEDBACK (Round {N}):
   {formatted markdown list of unresolved comments from .crit.json}
 
-  TASK:
-  Address each comment in the CRIT_FEEDBACK block by revising plan.md.
-  Reply to each addressed comment using:
-    crit comment --plan {change-name} --reply-to {id} --author "Claude Code" "<what you did>"
-  Skip the Deep Interview and Advice Phase (already completed).
-  Re-run the Detail Quality Gate.
-
-  PERSISTENCE: See {project path}/{WORKFLOW_DIR}/_shared/persistence-contract.md
-  - Primary: always write to {project path}/.sdd/{change-name}/
-  - Engram: save summary if available, skip silently if not
-
-  ENVELOPE: Your LAST output MUST be the SDD Envelope as a markdown table per
-  `{WORKFLOW_DIR}/_shared/envelope-contract.md`. Nothing may follow the envelope.'
+  When replying to comments, use:
+    crit comment --plan {change-name} --reply-to {id} --author "Claude Code" "<what you did>"'
 )
 ```
 
-The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK format defined in
-the Crit Plan Review Protocol section of `{WORKFLOW_DIR}/ORCHESTRATOR.opencode.md`.
+The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK format defined in the Crit Plan Review Protocol section of `{WORKFLOW_DIR}/ORCHESTRATOR.opencode.md`.
 
 ---
 
@@ -179,20 +119,3 @@ mem_save(
 ```
 
 This enables compaction recovery (see `{WORKFLOW_DIR}/_shared/recovery.md`).
-
----
-
-## WAVE-SCOPE Reference
-
-Every implement prompt includes a WAVE-SCOPE DISCIPLINE block. This is intentional and mandatory.
-The directive prevents the implementer from self-orchestrating additional batches — a failure mode
-observed when the implementer reads ahead in the Batch Assignment Table and launches its own Task()
-calls. Under wave-driven orchestration, the orchestrator owns progression; the implementer owns only
-the batch(es) explicitly listed in its launch prompt.
-
-Summary of the rule embedded in every implement prompt:
-- Implement ONLY the batch(es) listed in the TASK block
-- Mark [X] in plan.md IMMEDIATELY after each task (not at the end)
-- Run the Phase Checkpoint from plan.md (not a generic test suite) after each batch
-- Do NOT launch Task() or Skill() calls for other batches
-- Return envelope with status reflecting THIS batch/wave only


### PR DESCRIPTION
Third PR from the audit umbrella in #33. Closes M5 (move WAVE-SCOPE / QUALITY GATE / PERSISTENCE / ENVELOPE blocks out of launch templates).

Builds on #34 (M1+M2) and #36 (M3+M4+M6).

## Why

Every launch prompt repeated the same operational-contract blocks (`WAVE-SCOPE DISCIPLINE`, `QUALITY GATE`, `PERSISTENCE`, `ENVELOPE`) inline, even though those rules already live canonically in:

- `sdd-{phase}/SKILL.md` — the slimmed Persistence + Return Envelope + Self-Check sections from #36
- `_shared/persistence-contract.md` — Phase Artifact Save Convention, General Knowledge Persistence Mandate, Engram Availability Guard, Two-Step Recovery
- `_shared/envelope-contract.md` — envelope format + last-output rule

The orchestrator generates many launch prompts per workflow (one per implement batch, plus explore/plan/review/crit-re-entry/advisor). Repeating 30–40 lines of static contract per prompt drained the orchestrator's context window with content the sub-agent already loads from its `SKILL.md` at start.

This is the issue called out as Hallazgo D in the audit (#33).

## What changes

Strip the redundant operational-contract blocks across all 4 launch-template variants plus the Plan-Guidance re-entry in `advisor-templates.md`. Launch prompts now carry **dynamic context only**: project path, change name, artifact list, batch directive, optional `BACKGROUND MODE` warning when `run_in_background: true`.

What stays:

- **Skill-load directive** — only in variants that need it. Claude auto-loads via the `skills:` frontmatter; Copilot inlines SKILL.md into the agent file; both don't need a directive. OpenCode (1-line `opencode.json` prompts) and base / codex / factory need the explicit `Skill(...)` invocation with file fallback.
- **CONTEXT** block — project, change, artifact dir, previous artifacts (always dynamic).
- **TASK** block — phase-specific dynamic content.
- **BACKGROUND MODE warning** — only inline in templates with `run_in_background: true` (Claude parallel batch). It's a runtime-mode constraint that the SKILL.md can't predict.

What was removed (because it lives elsewhere now):

| Block removed from launch prompts | Where it lives now |
|-----------------------------------|-------------------|
| `WAVE-SCOPE DISCIPLINE: …` (implement) | `sdd-implement/SKILL.md` § Batch Execution + Self-Check |
| `QUALITY GATE: …` (implement) | `sdd-implement/SKILL.md` § Quality Gate |
| `PERSISTENCE: See …` + sub-bullets | `sdd-{phase}/SKILL.md` § Persistence + `_shared/persistence-contract.md` |
| `ENVELOPE: Your LAST output MUST be …` | `sdd-{phase}/SKILL.md` § Return Envelope + `_shared/envelope-contract.md` |
| Per-task numbered list (mark `[X]` / quality gate / envelope) | `sdd-implement/SKILL.md` § Batch Execution rules |

## Counts

| File                           | before | after | Δ    |
|--------------------------------|-------:|------:|-----:|
| `launch-templates.md`          |    220 |   160 | -60  |
| `launch-templates.claude.md`   |    234 |   139 | -95  |
| `launch-templates.copilot.md`  |    190 |   121 | -69  |
| `launch-templates.opencode.md` |    198 |   121 | -77  |
| `advisor-templates.md`         |    166 |   160 | -6   |
| **total (5 files)**            | **1008** | **701** | **-307** |

5 files, +94/-400.

## Cumulative impact (audit umbrella so far)

| PR     | M-tasks         | Net Δ | Running total |
|--------|-----------------|------:|--------------:|
| #34    | M1+M2           |   +81 |           +81 |
| #36    | M3+M4+M6        |  -563 |          -482 |
| **this** | **M5**        |  -307 |          **-789** |

The catalog SDD workflow is now ~789 lines lighter than before the audit, with the role-invariant enforcement (#34) and operational contracts canonicalized in `_shared/`.

## Test plan

- [ ] Smoke check on Claude: trigger an SDD workflow, run through one implement wave with at least one parallel batch. Verify the orchestrator emits launch prompts that omit the WAVE-SCOPE / QUALITY GATE / PERSISTENCE / ENVELOPE blocks, and that the sub-agent still does the right thing (because it loads `sdd-implement/SKILL.md` at start).
- [ ] Smoke check on OpenCode: same, verifying the `Your instructions are in {SKILLS_PATH}/sdd-{phase}/SKILL.md` directive is still present.
- [ ] Visual diff: confirm BACKGROUND MODE warning is preserved in the Claude parallel batch template and is the only "operational" content left in any prompt.
- [ ] DevRune renderer tests already pass with the change applied locally — no test asserts on the specific launch-template text we removed.

## Out of scope (still pending from #33)

- M7 — move legacy/conditional content (Multi-Root Hygiene, Crit Re-entry detail) into `references/`. Optional cleanup PR.
- M8 — drop the double `!`-mkdir in `sdd-orchestrator/SKILL.md` (canonical creation now in REGISTRY.md after #31). Tiny PR.