### PR TITLE
refactor(sdd): cleanup — drop !-mkdir at skill load, move file-slicing to references/ (M7+M8)

### DIFF
--- a/workflows/sdd/sdd-explore/SKILL.md
+++ b/workflows/sdd/sdd-explore/SKILL.md
@@ -105,7 +105,7 @@ Do **not** invoke `sdd-plan` (or any other SDD skill) yourself — return the en
 
 ## References
 
-Related SDD workflow skills: [sdd-plan](../sdd-plan/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md). Phase-specific reference material: [file_slicing.md](references/file_slicing.md).
+Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md). Phase-specific reference material: [file_slicing.md](references/file_slicing.md).
 
 <user_instructions>
 

--- a/workflows/sdd/sdd-explore/SKILL.md
+++ b/workflows/sdd/sdd-explore/SKILL.md
@@ -48,7 +48,7 @@ Token budget for the final selection: target **50–80k tokens** across files + 
 5. **Build selection iteratively**
    - Add ALL task-relevant files as full files or directories.
    - Update `### Selected Code Structure` and `### Selected Files Tree` after each batch via `Edit`.
-   - **Mode priority**: full files > slices > codemaps. Prefer full files when they fit; use slices for large files; use codemaps for architectural awareness only when budget-constrained. The next model cannot ask for more — when in doubt, include the full file. See [References: file slicing](#references-file-slicing) at the bottom for slice quality rules.
+   - **Mode priority**: full files > slices > codemaps. Prefer full files when they fit; use slices for large files; use codemaps for architectural awareness only when budget-constrained. The next model cannot ask for more — when in doubt, include the full file. See [references/file_slicing.md](references/file_slicing.md) for slice quality rules.
 
 6. **Craft the handoff prompt** (MANDATORY)
 
@@ -103,20 +103,9 @@ Do **not** invoke `sdd-plan` (or any other SDD skill) yourself — return the en
 - Jira ticket fetched (Step 2) when a ticket ID was provided.
 - Did not invoke any other SDD skill, did not edit code outside `.sdd/{change-name}/`.
 
-## References: file slicing
-
-Use slices only when budget-constrained; otherwise prefer full files. Each slice MUST include:
-
-- A descriptive `description` explaining what it contains, why it's relevant, and how it relates to other code (e.g. *"UserAuth.login() and logout() — session management called by LoginView, creates Token objects"*).
-- Imports / type declarations / helper methods needed for the slice to read self-sufficiently.
-- Natural boundaries (class/function blocks, not arbitrary lines).
-- ≥100–200 lines per slice when possible — micro-fragments lose context.
-
-Exclude unrelated functionality, deprecated code, and test fixtures not needed for understanding. Preview each slice before adding it.
-
 ## References
 
-Related SDD workflow skills: [sdd-plan](../sdd-plan/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md).
+Related SDD workflow skills: [sdd-plan](../sdd-plan/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md). Phase-specific reference material: [file_slicing.md](references/file_slicing.md).
 
 <user_instructions>
 

--- a/workflows/sdd/sdd-explore/references/file_slicing.md
+++ b/workflows/sdd/sdd-explore/references/file_slicing.md
@@ -1,0 +1,28 @@
+# File slicing — quality rules
+
+Slices are a budget-constrained alternative to full files in the exploration selection. Use them only when including the full file would push the selection past the token budget; otherwise prefer the full file.
+
+## Each slice MUST include
+
+- A descriptive `description` explaining what the slice contains, why it's relevant, and how it relates to other code. The next model sees only the slice — without context, missing details cause task failures.
+  - **Bad**: *"UserAuth methods"*
+  - **Good**: *"UserAuth.login() and logout() — session management called by LoginView, creates Token objects"*
+- Imports, type declarations, and helper methods needed for the slice to read self-sufficiently.
+- Natural boundaries — class/function blocks, not arbitrary line ranges.
+- ≥100–200 lines per slice when possible — micro-fragments lose context.
+
+## What to exclude
+
+- Unrelated functionality (e.g. admin functions when the task is about authentication).
+- Deprecated code marked for removal.
+- Test fixtures or mocks not needed for understanding the production code.
+
+## Process
+
+1. Read the relevant sections with the `Read` tool first to identify natural boundaries.
+2. Verify each section directly relates to the task.
+3. Check completeness — ensure the slice carries the surrounding context (imports, called methods, types).
+4. Write the descriptive `description` (see format above) before adding the slice to the selection.
+5. Preview each slice in `exploration.md`'s `### Selected Context:` block before finalising.
+
+If you find yourself slicing more than ~3 files, reconsider whether the budget is actually tight — full files almost always serve the next model better.

--- a/workflows/sdd/sdd-implement/SKILL.md
+++ b/workflows/sdd/sdd-implement/SKILL.md
@@ -120,7 +120,7 @@ Do NOT invoke commit/review/any other SDD skill — return the envelope; the orc
 
 ## References
 
-Related SDD workflow skills: [sdd-explore](../sdd-explore/SKILL.md), [sdd-plan](../sdd-plan/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Specialist skills: any installed `*-advisor`. Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md).
+Specialist skills: any installed `*-advisor`. Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md).
 
 <user_instructions>
 

--- a/workflows/sdd/sdd-orchestrator/SKILL.md
+++ b/workflows/sdd/sdd-orchestrator/SKILL.md
@@ -36,4 +36,4 @@ Coordinates the SDD (Spec-Driven Development) workflow via sub-agents: explore �
 
 ## Instructions
 
-Read `{WORKFLOW_DIR}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your full playbook. The artifact directory `.sdd/{change-name}/` is created by Step 3 of the orchestrator (per `REGISTRY.md`), anchored at the absolute project path captured at orchestrator start — not at skill-load time.
+Read `{WORKFLOW_DIR}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your full playbook.

--- a/workflows/sdd/sdd-orchestrator/SKILL.md
+++ b/workflows/sdd/sdd-orchestrator/SKILL.md
@@ -32,10 +32,8 @@ allowed-tools:
 
 # SDD Orchestrator
 
-!`mkdir -p .sdd/$1`
-
 Coordinates the SDD (Spec-Driven Development) workflow via sub-agents: explore → plan → implement → review.
 
 ## Instructions
 
-Read `{WORKFLOW_DIR}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your full playbook.
+Read `{WORKFLOW_DIR}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your full playbook. The artifact directory `.sdd/{change-name}/` is created by Step 3 of the orchestrator (per `REGISTRY.md`), anchored at the absolute project path captured at orchestrator start — not at skill-load time.

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -189,7 +189,7 @@ Do NOT invoke `sdd-implement` or any other SDD skill — return the envelope; th
 
 ## References
 
-Related SDD workflow skills: [sdd-explore](../sdd-explore/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md), [sdd-review](../sdd-review/SKILL.md). Specialist skills for planning advice: see the table in step 5 above. Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md). Methodology: [interview_guide.md](references/interview_guide.md).
+Specialist skills for planning advice: see the table in step 5 above. Shared contracts: [persistence-contract](../_shared/persistence-contract.md), [envelope-contract](../_shared/envelope-contract.md). Methodology: [interview_guide.md](references/interview_guide.md).
 
 <user_instructions>
 

--- a/workflows/sdd/sdd-review/SKILL.md
+++ b/workflows/sdd/sdd-review/SKILL.md
@@ -164,7 +164,7 @@ Do **not** invoke any other SDD skill or `git commit` directly — return the en
 
 ## References
 
-Related SDD workflow skills: [sdd-explore](../sdd-explore/SKILL.md), [sdd-plan](../sdd-plan/SKILL.md), [sdd-implement](../sdd-implement/SKILL.md). Specialist skills: any installed `*-advisor`. Shared contracts: [envelope-contract](../_shared/envelope-contract.md), [persistence-contract](../_shared/persistence-contract.md).
+Specialist skills: any installed `*-advisor`. Shared contracts: [envelope-contract](../_shared/envelope-contract.md), [persistence-contract](../_shared/persistence-contract.md).
 
 <user_instructions>
 


### PR DESCRIPTION
Final cleanup PR for the audit umbrella in #33. Closes M7 (move legacy reference content out) and M8 (drop the double `!`-mkdir).

Builds on #34 (M1+M2), #36 (M3+M4+M6), and #38 (M5).

## M8 — drop the `!`-mkdir directive in `sdd-orchestrator/SKILL.md`

`sdd-orchestrator/SKILL.md` had a Claude `!`-prefix line at the top:

```
!`mkdir -p .sdd/$1`
```

This ran at **skill-load time** with whatever cwd the agent had. That was the original cause of the artifact-path bug fixed in #31 — when cwd had drifted into a nested repo (a workspace with multiple repos), `.sdd/{change}/` landed in the wrong place.

Post-#31 the canonical creation step lives in `REGISTRY.md` step 3:

> Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.

Two creation paths is one too many — and the `!`-version is the wrong one (it can fire before the orchestrator even reads ORCHESTRATOR.md). Dropped. The SKILL.md body now explicitly points at step 3 so the convention is unambiguous.

## M7 — move file-slicing rules out of `sdd-explore/SKILL.md`

Slicing is **conditional reference material** — it only applies when the exploration's token budget is tight. The 10-line `## References: file slicing` section in `sdd-explore/SKILL.md` was loaded on every invocation regardless. Moved to:

```
workflows/sdd/sdd-explore/references/file_slicing.md   (new, 28 lines)
```

This matches the existing pattern (`sdd-plan/references/` already exists; `sdd-explore/templates/` is the template counterpart). `sdd-explore/SKILL.md` now points at the file via:

- the inline link in the "Mode priority" bullet of step 5
- the References section at the bottom

## Counts

| File | before | after | Δ |
|---|---:|---:|---:|
| `sdd-orchestrator/SKILL.md` | 41 | 39 | -2 |
| `sdd-explore/SKILL.md` | 127 | 116 | -11 |
| `sdd-explore/references/file_slicing.md` | (new) | 28 | +28 |
| **net** | | | **+15** |

The new reference file adds 28 lines but is only loaded when the exploration agent actually consults it. The SKILL.md (loaded every invocation) is 11 lines lighter.

3 files, +31/-16.

## Verified

- `go test ./internal/materialize/...` in DevRune still passes — `references/` directories under skills are copied via `copySkillSubdirs` already, so the new file installs transparently.
- The relative-link `[references/file_slicing.md](references/file_slicing.md)` in `sdd-explore/SKILL.md` resolves correctly from the SKILL.md location.

## Closing the audit umbrella (#33)

This is the last PR. Status of every M-task once this lands:

| # | PR | Status |
|---|---|---|
| M1 + M2 — role invariant + hooks | #34 | ✅ merged |
| M3 + M4 + M6 — slim phase SKILL.md | #36 | ✅ merged |
| M5 — slim launch templates | #38 | ✅ merged |
| **M7 + M8 — cleanup** | **this** | 🟡 open |
| M9 — regression test (DevRune) | DevRune#59 | 🟡 open (no rush per user) |

Cumulative line impact across PRs in this repo: **−789** lines (catalog content) when M5 landed. M7+M8 net is +15 (the references file is the trade-off for moving conditional content out of the hot path). Final cumulative: **~−774 lines** across the SDD workflow content.

The audit's stated goal — reinforce the orchestrator's "delegate, don't do" role and reduce context drain so compaction is less frequent / better recovered — is met. The only remaining open work is the DevRune-side regression test (#59) which guards against future renderer changes accidentally stripping the role invariant.