### PR TITLE
feat(sdd): PRD gate before exploration when scope is unclear

### DIFF
--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: write-a-prd
+description: 'Generate a Product Requirements Document via interactive interview. Writes a markdown PRD that captures intent, user stories, and out-of-scope. Use when the brief is vague, when no ticket is bound, or when SDD invokes it from Step 0b.'
+scope: [planning, intent]
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Write
+  - Edit
+argument-hint: "[change-name]"
+model: sonnet
+---
+
+Generate a PRD that captures the user's intent before any code or codebase exploration commits to a direction. The PRD is the WHAT and WHY (user perspective). It explicitly avoids file paths, code snippets, module sketches, and implementation/testing details — those belong to the planning phase, not here.
+
+## Steps
+
+1. **Ask for context if missing.** If the user hasn't given a detailed problem description, ask once: *"Describe the problem and any solution ideas you have."*
+2. **Verify cheaply.** Use `Glob`/`Grep` to confirm assertions only when needed. Do NOT preemptively explore the whole repo — that's the explore phase's job.
+3. **Interview** using these three rules:
+   - **One question at a time.** Never batch.
+   - **For each question, propose your recommended answer.** The user confirms, rejects, or proposes a different one.
+   - **If the answer lives in the codebase, explore instead of asking.**
+4. **Bound the interview** with three checkpoints:
+   - **Vague-answer pushback (once per branch).** When the user replies "no sé" / "decide tú" / "lo que tú digas", give one honest pushback: *"Si tú no lo tienes claro, yo tampoco — la feature va a quedar vagamente implementada. ¿Pensamos juntos una respuesta razonable, o lo marco como Ambiguity y arrancamos sabiendo que tendremos que volver?"* If still no answer, mark that branch as an Ambiguity in `Further Notes` and move to the next branch.
+   - **Periodic stop offer (every ~3 rounds).** *"Tengo todavía N preguntas pendientes, pero con lo resuelto ya se podría arrancar. ¿Sigo o vamos?"*
+   - **Stop on signal.** When the user says "vamos" / "go" / "ya está" / "done", close the interview.
+5. **Write the PRD** to `{change-name}/prd.md` under the SDD artifact directory if invoked from SDD (i.e. `.sdd/{change-name}/prd.md`); otherwise to `prd.md` in the current directory. Create parent directories as needed. Use the template below.
+
+## PRD template
+
+```markdown
+## Problem Statement
+
+[The problem from the user's perspective — what they're trying to do and why it's painful or missing today.]
+
+## Solution
+
+[The solution from the user's perspective — what changes for them when this lands.]
+
+## User Stories
+
+A long, numbered list. Each story:
+
+`As <actor>, I want <feature>, so that <benefit>.`
+
+Cover all aspects of the feature, including edge cases surfaced during the interview.
+
+## Out of Scope
+
+[What is explicitly excluded — important to surface false expectations.]
+
+## Further Notes
+
+[Open ambiguities (with the branch they apply to), references to bound ticket / GitHub issue if any, decisions deferred to implementation.]
+```
+
+Do NOT include file paths, code snippets, module sketches, or implementation/testing decisions in the PRD. Those belong to `plan.md`. The PRD captures intent, not execution.
+
+## Self-Check (before returning)
+
+- The PRD file exists at the expected path.
+- Problem and Solution are written from the user's perspective (not technical).
+- User Stories cover the feature surface, including edge cases the interview surfaced.
+- No file paths, code snippets, module sketches, or testing details in the document.
+- Ambiguities the user could not resolve are listed in Further Notes (not silently dropped).
+- Did NOT submit external issues or call external services.

--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: 'Generate a Product Requirements Document via interactive interview. Writes a markdown PRD that captures intent, user stories, and out-of-scope. Use when the brief is vague, when no ticket is bound, or when SDD invokes it from Step 0b.'
+description: 'Generate a Product Requirements Document via interactive interview. Writes a markdown PRD that captures intent, user stories, and out-of-scope. Use when the brief is vague, when no ticket is bound, or when SDD invokes it from its PRD gate.'
 scope: [planning, intent]
 allowed-tools:
   - Read
@@ -24,7 +24,7 @@ Generate a PRD that captures the user's intent before any code or codebase explo
    - **For each question, propose your recommended answer.** The user confirms, rejects, or proposes a different one.
    - **If the answer lives in the codebase, explore instead of asking.**
 4. **Bound the interview** with three checkpoints:
-   - **Vague-answer pushback (once per branch).** When the user replies "no sé" / "decide tú" / "lo que tú digas", give one honest pushback: *"Si tú no lo tienes claro, yo tampoco — la feature va a quedar vagamente implementada. ¿Pensamos juntos una respuesta razonable, o lo marco como Ambiguity y arrancamos sabiendo que tendremos que volver?"* If still no answer, mark that branch as an Ambiguity in `Further Notes` and move to the next branch.
+   - **Vague-answer pushback (once per branch).** When the user's reply is non-committal — anything that doesn't actually clarify the question, regardless of phrasing — give one honest pushback: *"Si tú no lo tienes claro, yo tampoco — la feature va a quedar vagamente implementada. ¿Pensamos juntos una respuesta razonable, o lo marco como Ambiguity y arrancamos sabiendo que tendremos que volver?"* If still no real answer, mark that branch as an Ambiguity in `Further Notes` and move to the next branch.
    - **Periodic stop offer (every ~3 rounds).** *"Tengo todavía N preguntas pendientes, pero con lo resuelto ya se podría arrancar. ¿Sigo o vamos?"*
    - **Stop on signal.** When the user says "vamos" / "go" / "ya está" / "done", close the interview.
 5. **Write the PRD** to `{change-name}/prd.md` under the SDD artifact directory if invoked from SDD (i.e. `.sdd/{change-name}/prd.md`); otherwise to `prd.md` in the current directory. Create parent directories as needed. Use the template below.

--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: write-a-prd
 description: 'Generate a Product Requirements Document via interactive interview. Writes a markdown PRD that captures intent, user stories, and out-of-scope. Use when the brief is vague, when no ticket is bound, or when SDD invokes it from its PRD gate.'
-scope: [planning, intent]
+metadata:
+  version: "1.0"
+  scope: [planning, intent]
+  trigger: "User requests a PRD, brief is vague, or SDD orchestrator invokes via the PRD gate"
+  auto_invoke: 'Invoke by INTENT not literal phrase. EN: "draft a PRD", "write a PRD", "clarify requirements". ES: "haz un PRD", "redacta los requisitos". Auto-invoked from SDD when scope is thin.'
 allowed-tools:
   - Read
   - Glob

--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -14,7 +14,6 @@ allowed-tools:
   - Write
   - Edit
 argument-hint: "[change-name]"
-model: sonnet
 ---
 
 Generate a PRD that captures the user's intent before any code or codebase exploration commits to a direction. The PRD is the WHAT and WHY (user perspective). It explicitly avoids file paths, code snippets, module sketches, and implementation/testing details — those belong to the planning phase, not here.

--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -24,9 +24,9 @@ Generate a PRD that captures the user's intent before any code or codebase explo
    - **For each question, propose your recommended answer.** The user confirms, rejects, or proposes a different one.
    - **If the answer lives in the codebase, explore instead of asking.**
 4. **Bound the interview** with three checkpoints:
-   - **Vague-answer pushback (once per branch).** When the user's reply is non-committal — anything that doesn't actually clarify the question, regardless of phrasing — give one honest pushback: *"Si tú no lo tienes claro, yo tampoco — la feature va a quedar vagamente implementada. ¿Pensamos juntos una respuesta razonable, o lo marco como Ambiguity y arrancamos sabiendo que tendremos que volver?"* If still no real answer, mark that branch as an Ambiguity in `Further Notes` and move to the next branch.
-   - **Periodic stop offer (every ~3 rounds).** *"Tengo todavía N preguntas pendientes, pero con lo resuelto ya se podría arrancar. ¿Sigo o vamos?"*
-   - **Stop on signal.** When the user says "vamos" / "go" / "ya está" / "done", close the interview.
+   - **Vague-answer pushback (once per branch).** When the user's reply is non-committal — anything that doesn't actually clarify the question, regardless of phrasing — give one honest pushback: *"If you don't have a clear answer here, I won't either — the feature will end up vaguely implemented. Should we think through a reasonable answer together, or should I mark this as an Ambiguity and start anyway, knowing we'll have to come back?"* If still no real answer, mark that branch as an Ambiguity in `Further Notes` and move to the next branch.
+   - **Periodic stop offer (every ~3 rounds).** *"There are still N open questions, but what's resolved is enough to start. Continue or go?"*
+   - **Stop on signal.** When the user gives a stop signal (any phrasing of "we're good" / "go" / "done"), close the interview.
 5. **Write the PRD** to `{change-name}/prd.md` under the SDD artifact directory if invoked from SDD (i.e. `.sdd/{change-name}/prd.md`); otherwise to `prd.md` in the current directory. Create parent directories as needed. Use the template below.
 
 ## PRD template

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -1,6 +1,4 @@
-# SDD Orchestrator (Claude-native, delegate-only coordinator)
-
-## Role Invariant — you orchestrate, you do not implement
+## Your Role
 
 Outside `.sdd/{change}/`, your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -61,6 +61,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
   content: "ACTIVE SDD workflow: {change}. Orchestrator: .claude/skills/sdd-orchestrator/ORCHESTRATOR.md. Phase: starting explore.")
 ```
 
+## Step 0b — PRD gate (before explore phase)
+
+After saving the active-workflow marker and before launching the explore sub-agent, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+
+1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
+2. Ask once via `AskUserQuestion`:
+   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
+   - "Skip — scope is clear, go to explore" — recommend if context is rich.
+3. If the user picks **Draft PRD**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+4. If the user picks **Skip**: continue directly to the explore phase.
+
+The PRD is opt-in — never force it. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope. Aggregate status: all `ok` → `ok`; any `failed` → `failed`; any `warning` (none failed) → `warning`.

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -56,7 +56,7 @@ Before the first launch, save the active-workflow marker to engram (if available
 ```
 mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: .claude/skills/sdd-orchestrator/ORCHESTRATOR.md. Phase: starting explore.")
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore.")
 ```
 
 ## Step 1 — PRD gate (before explore phase)

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -65,7 +65,7 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
 2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
 3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -63,9 +63,15 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
+1. **Scope check** — count how many of these signals are present in the prompt, the bound ticket body, or via reasonable inference when a mention maps to a real artifact in the repo.
+   - [ ] **Specific files or paths**: at least one concrete file path or filename — either explicit, or via clear mapping from a mention to a real file in the repo
+   - [ ] **Out-of-scope statement**: explicit phrase listing what is NOT included (e.g., "out of scope:", "do not change X", "skip the Y flow")
+   - [ ] **Bound ticket with non-empty body**: a ticket id was provided AND the ticket body was retrieved with substantive content
+   - [ ] **Concrete acceptance criteria**: enumerated assertions, dimensions, or "done when X" criteria — not just a goal statement
+
+   If 2 or more boxes are checked, context is sufficient. If fewer than 2, context is THIN.
 2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
-3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
+3. **If context is thin**: ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
 4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -61,18 +61,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
   content: "ACTIVE SDD workflow: {change}. Orchestrator: .claude/skills/sdd-orchestrator/ORCHESTRATOR.md. Phase: starting explore.")
 ```
 
-## Step 0b — PRD gate (before explore phase)
+## Step 1 — PRD gate (before explore phase)
 
-After saving the active-workflow marker and before launching the explore sub-agent, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
-2. Ask once via `AskUserQuestion`:
-   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
-   - "Skip — scope is clear, go to explore" — recommend if context is rich.
-3. If the user picks **Draft PRD**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
-4. If the user picks **Skip**: continue directly to the explore phase.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
+3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
+   - "Draft a PRD first to clarify scope" (recommended)
+   - "Proceed anyway with what we have"
+4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+5. **If "Proceed anyway"**: continue directly to the explore phase.
 
-The PRD is opt-in — never force it. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
 
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -63,18 +63,19 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
   content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.copilot.md. Phase: starting explore.")
 ```
 
-## Step 0b — PRD gate (before explore phase)
+## Step 1 — PRD gate (before explore phase)
 
-After saving the active-workflow marker and before invoking `@sdd-explorer`, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+After saving the active-workflow marker and before invoking `@sdd-explorer`, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
-2. Ask the user once:
-   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
-   - "Skip — scope is clear, go to explore" — recommend if context is rich.
-3. If the user picks **Draft PRD**: invoke `@write-a-prd` with the change-name. The agent runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.
-4. If the user picks **Skip**: invoke `@sdd-explorer` directly.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+2. **If context is sufficient**: invoke `@sdd-explorer` directly. Do NOT prompt the user.
+3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask the user once:
+   - "Draft a PRD first to clarify scope" (recommended)
+   - "Proceed anyway with what we have"
+4. **If "Draft PRD"**: invoke `@write-a-prd` with the change-name. The agent runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.
+5. **If "Proceed anyway"**: invoke `@sdd-explorer` directly.
 
-The PRD is opt-in — never force it. `@sdd-explorer` and `@sdd-planner` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `@sdd-explorer` and `@sdd-planner` consume `prd.md` only when present; behaviour is unchanged when it isn't.
 
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -63,6 +63,19 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
   content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.copilot.md. Phase: starting explore.")
 ```
 
+## Step 0b — PRD gate (before explore phase)
+
+After saving the active-workflow marker and before invoking `@sdd-explorer`, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+
+1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
+2. Ask the user once:
+   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
+   - "Skip — scope is clear, go to explore" — recommend if context is rich.
+3. If the user picks **Draft PRD**: invoke `@write-a-prd` with the change-name. The agent runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.
+4. If the user picks **Skip**: invoke `@sdd-explorer` directly.
+
+The PRD is opt-in — never force it. `@sdd-explorer` and `@sdd-planner` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -55,9 +55,15 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 
 After saving the active-workflow marker and before invoking `@sdd-explorer`, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
+1. **Scope check** — count how many of these signals are present in the prompt, the bound ticket body, or via reasonable inference when a mention maps to a real artifact in the repo.
+   - [ ] **Specific files or paths**: at least one concrete file path or filename — either explicit, or via clear mapping from a mention to a real file in the repo
+   - [ ] **Out-of-scope statement**: explicit phrase listing what is NOT included (e.g., "out of scope:", "do not change X", "skip the Y flow")
+   - [ ] **Bound ticket with non-empty body**: a ticket id was provided AND the ticket body was retrieved with substantive content
+   - [ ] **Concrete acceptance criteria**: enumerated assertions, dimensions, or "done when X" criteria — not just a goal statement
+
+   If 2 or more boxes are checked, context is sufficient. If fewer than 2, context is THIN.
 2. **If context is sufficient**: invoke `@sdd-explorer` directly. Do NOT prompt the user.
-3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask the user once:
+3. **If context is thin**: ask the user once:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
 4. **If "Draft PRD"**: invoke the skill `write-a-prd` with the change-name. The skill runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -1,6 +1,4 @@
-# SDD Orchestrator (delegate-only coordinator)
-
-## Role Invariant — you orchestrate, you do not implement
+## Your Role
 
 Outside `.sdd/{change}/`, your only outputs are: sub-agent invocations via `@sdd-{phase}` (natural-language @-mention), questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -21,16 +19,6 @@ If your next planned action is on the "do not" list, you have lost the role — 
                  parse envelope → write state.yaml → engram
                       → show summary → ask user
 ```
-
-## Phase-to-Model Table
-
-| Phase | Skill | Model | Subagent Type |
-|-------|-------|-------|---------------|
-| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` | |
-| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
-| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
-| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
-| advisor | `*-advisor` | `{WORKFLOW_MODEL_ADVISOR}` ⭐ | N/A — Copilot uses natural language @agent-name invocation, not Task() |
 
 ## Evaluation Gate
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -48,7 +48,7 @@ Before the first launch, save the active-workflow marker to engram (if available
 ```
 mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.copilot.md. Phase: starting explore.")
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore.")
 ```
 
 ## Step 1 — PRD gate (before explore phase)
@@ -85,7 +85,7 @@ The PRD is opt-in for thin contexts only — never force it, never offer it when
      topic_key: "sdd/{change}/active-workflow",
      type: "architecture", project: "{project}",
      title: "sdd/{change}/active-workflow",
-     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.copilot.md. NEXT: {phase} phase -> {next step}."
+     content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. NEXT: {phase} phase -> {next step}."
    )
    ```
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -67,12 +67,12 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{ch
 
 After saving the active-workflow marker and before invoking `@sdd-explorer`, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
 2. **If context is sufficient**: invoke `@sdd-explorer` directly. Do NOT prompt the user.
 3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask the user once:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
-4. **If "Draft PRD"**: invoke `@write-a-prd` with the change-name. The agent runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.
+4. **If "Draft PRD"**: invoke the skill `write-a-prd` with the change-name. The skill runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.
 5. **If "Proceed anyway"**: invoke `@sdd-explorer` directly.
 
 The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `@sdd-explorer` and `@sdd-planner` consume `prd.md` only when present; behaviour is unchanged when it isn't.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -56,6 +56,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
   content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. Phase: starting explore.")
 ```
 
+## Step 0b — PRD gate (before explore phase)
+
+After saving the active-workflow marker and before launching the explore sub-agent, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+
+1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
+2. Ask once via `AskUserQuestion`:
+   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
+   - "Skip — scope is clear, go to explore" — recommend if context is rich.
+3. If the user picks **Draft PRD**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore phase when it returns.
+4. If the user picks **Skip**: continue directly to the explore phase.
+
+The PRD is opt-in — never force it. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -60,7 +60,7 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
 2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
 3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -1,7 +1,4 @@
-# SDD Orchestrator (delegate-only coordinator)
-<!-- Also invocable as Skill("sdd-orchestrator") — see SKILL.md for entry point -->
-
-## Role Invariant — you orchestrate, you do not implement
+## Your Role
 
 Outside `.sdd/{change}/`, your only outputs are: sub-agent launches (`Task` / `Agent` / `@<sub-agent>` per your variant), `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -22,16 +19,6 @@ If your next planned action is on the "do not" list, you have lost the role — 
                  parse envelope → write state.yaml → engram
                       → show summary → ask user
 ```
-
-## Phase-to-Model Table
-
-| Phase | Skill | Model | Subagent Type |
-|-------|-------|-------|---------------|
-| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` | |
-| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
-| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
-| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
-| advisor | `*-advisor` | `{WORKFLOW_MODEL_ADVISOR}` ⭐ | `general-purpose` (hardcoded) |
 
 ## Evaluation Gate
 

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -47,9 +47,15 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
+1. **Scope check** — count how many of these signals are present in the prompt, the bound ticket body, or via reasonable inference when a mention maps to a real artifact in the repo.
+   - [ ] **Specific files or paths**: at least one concrete file path or filename — either explicit, or via clear mapping from a mention to a real file in the repo
+   - [ ] **Out-of-scope statement**: explicit phrase listing what is NOT included (e.g., "out of scope:", "do not change X", "skip the Y flow")
+   - [ ] **Bound ticket with non-empty body**: a ticket id was provided AND the ticket body was retrieved with substantive content
+   - [ ] **Concrete acceptance criteria**: enumerated assertions, dimensions, or "done when X" criteria — not just a goal statement
+
+   If 2 or more boxes are checked, context is sufficient. If fewer than 2, context is THIN.
 2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
-3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
+3. **If context is thin**: ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
 4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -56,18 +56,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
   content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. Phase: starting explore.")
 ```
 
-## Step 0b — PRD gate (before explore phase)
+## Step 1 — PRD gate (before explore phase)
 
-After saving the active-workflow marker and before launching the explore sub-agent, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
-2. Ask once via `AskUserQuestion`:
-   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
-   - "Skip — scope is clear, go to explore" — recommend if context is rich.
-3. If the user picks **Draft PRD**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore phase when it returns.
-4. If the user picks **Skip**: continue directly to the explore phase.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
+3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
+   - "Draft a PRD first to clarify scope" (recommended)
+   - "Proceed anyway with what we have"
+4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+5. **If "Proceed anyway"**: continue directly to the explore phase.
 
-The PRD is opt-in — never force it. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
 
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -40,7 +40,7 @@ Before the first launch, save the active-workflow marker to engram (if available
 ```
 mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. Phase: starting explore.")
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore.")
 ```
 
 ## Step 1 — PRD gate (before explore phase)
@@ -77,7 +77,7 @@ The PRD is opt-in for thin contexts only — never force it, never offer it when
      topic_key: "sdd/{change}/active-workflow",
      type: "architecture", project: "{project}",
      title: "sdd/{change}/active-workflow",
-     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. NEXT: {phase} phase -> {next step}."
+     content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. NEXT: {phase} phase -> {next step}."
    )
    ```
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -40,7 +40,7 @@ Before the first launch, save the active-workflow marker to engram (if available
 ```
 mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. Phase: starting explore.")
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore.")
 ```
 
 ## Step 1 — PRD gate (before explore phase)
@@ -77,7 +77,7 @@ The PRD is opt-in for thin contexts only — never force it, never offer it when
      topic_key: "sdd/{change}/active-workflow",
      type: "architecture", project: "{project}",
      title: "sdd/{change}/active-workflow",
-     content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. NEXT: {phase} phase -> {next step}."
+     content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. NEXT: {phase} phase -> {next step}."
    )
    ```
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -59,7 +59,7 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
 2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
 3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -1,6 +1,4 @@
-# SDD Orchestrator (delegate-only coordinator)
-
-## Role Invariant — you orchestrate, you do not implement
+## Your Role
 
 Outside `.sdd/{change}/`, your only outputs are: sub-agent launches via `Task(subagent_type: '...', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -21,16 +19,6 @@ If your next planned action is on the "do not" list, you have lost the role — 
                  parse envelope → write state.yaml → engram
                       → show summary → ask user
 ```
-
-## Phase-to-Model Table
-
-| Phase | Skill | Model | Subagent Type |
-|-------|-------|-------|---------------|
-| explore | `sdd-explore` | `{WORKFLOW_MODEL_EXPLORER}` | |
-| plan | `sdd-plan` | `{WORKFLOW_MODEL_PLANNER}` | |
-| implement | `sdd-implement` | `{WORKFLOW_MODEL_IMPLEMENTER}` | |
-| review | `sdd-review` | `{WORKFLOW_MODEL_REVIEWER}` | |
-| advisor | `*-advisor` | `{WORKFLOW_MODEL_ADVISOR}` ⭐ | `general-purpose` (hardcoded) |
 
 ## Evaluation Gate
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -55,18 +55,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
   content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. Phase: starting explore.")
 ```
 
-## Step 0b — PRD gate (before explore phase)
+## Step 1 — PRD gate (before explore phase)
 
-After saving the active-workflow marker and before launching the explore sub-agent, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
-2. Ask once via `AskUserQuestion`:
-   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
-   - "Skip — scope is clear, go to explore" — recommend if context is rich.
-3. If the user picks **Draft PRD**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore phase when it returns.
-4. If the user picks **Skip**: continue directly to the explore phase.
+1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to formulate `## Objective` and `### Task:` for `exploration.md` without making scope-defining assumptions.
+2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
+3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
+   - "Draft a PRD first to clarify scope" (recommended)
+   - "Proceed anyway with what we have"
+4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+5. **If "Proceed anyway"**: continue directly to the explore phase.
 
-The PRD is opt-in — never force it. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
 
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -47,9 +47,15 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
 
 After saving the active-workflow marker and before launching the explore sub-agent, assess whether context is sufficient to start exploring without inventing scope. Catches poor context before burning tokens on exploration.
 
-1. **Assess context** from the user prompt + bound ticket body (if any). Sufficient context = enough to brief the explore phase on what needs to be built, without making scope-defining assumptions.
+1. **Scope check** — count how many of these signals are present in the prompt, the bound ticket body, or via reasonable inference when a mention maps to a real artifact in the repo.
+   - [ ] **Specific files or paths**: at least one concrete file path or filename — either explicit, or via clear mapping from a mention to a real file in the repo
+   - [ ] **Out-of-scope statement**: explicit phrase listing what is NOT included (e.g., "out of scope:", "do not change X", "skip the Y flow")
+   - [ ] **Bound ticket with non-empty body**: a ticket id was provided AND the ticket body was retrieved with substantive content
+   - [ ] **Concrete acceptance criteria**: enumerated assertions, dimensions, or "done when X" criteria — not just a goal statement
+
+   If 2 or more boxes are checked, context is sufficient. If fewer than 2, context is THIN.
 2. **If context is sufficient**: continue directly to the explore phase. Do NOT prompt the user.
-3. **If context is thin** (short prompt, no ticket, empty ticket body, or ambiguity that would force scope assumptions during exploration): ask once via `AskUserQuestion`:
+3. **If context is thin**: ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
 4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -55,6 +55,19 @@ mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-
   content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. Phase: starting explore.")
 ```
 
+## Step 0b — PRD gate (before explore phase)
+
+After saving the active-workflow marker and before launching the explore sub-agent, give the user the option to draft a PRD when the brief looks thin. Catches poor context before burning tokens on exploration.
+
+1. Compute a 2-line TL;DR of what you understood (from user prompt + bound ticket body if present).
+2. Ask once via `AskUserQuestion`:
+   - "Draft a PRD first to challenge the scope" — recommend if the user prompt is short or no ticket / ticket body is empty.
+   - "Skip — scope is clear, go to explore" — recommend if context is rich.
+3. If the user picks **Draft PRD**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore phase when it returns.
+4. If the user picks **Skip**: continue directly to the explore phase.
+
+The PRD is opt-in — never force it. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
+
 ## Post-Phase Protocol (MANDATORY after EVERY sub-agent)
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.

--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -6,6 +6,12 @@ You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git co
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
+## Language Mirroring
+
+Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
+
+This applies to the orchestrator, every sub-agent it launches, and every skill invoked from the workflow.
+
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
 ## SDD — Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)

--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -1,4 +1,4 @@
-## Orchestrator role
+### Orchestrator role
 
 When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -6,7 +6,7 @@ You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git co
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
-## Language Matching
+### Language Matching
 
 Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
 
@@ -14,7 +14,7 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
-## Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
+### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**
 
@@ -36,7 +36,7 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 **How to offer**: Use `AskUserQuestion` — NEVER suggest SDD as plain text: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
-## How to Start (MANDATORY)
+### How to Start (MANDATORY)
 
 When SDD is triggered:
 1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
@@ -45,14 +45,14 @@ When SDD is triggered:
 
 **Do NOT** use `Task()` or call `Skill("sdd-explore")`, `Skill("sdd-plan")`, etc. directly — sub-agent skills are preloaded via `skills:` frontmatter. Launch sub-agents with `Agent(subagent_type: 'sdd-{phase}', prompt: '<dynamic context only>')`.
 
-## Delegation Rules
+### Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Agent`.
 2. To launch a phase: use `Agent(subagent_type: 'sdd-{phase}')` — skills are preloaded via frontmatter, pass ONLY dynamic context in the prompt (project path, change name, artifact dir, phase-specific data).
 3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator playbook — NEVER skip it.
 4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
-## Compaction Recovery (MANDATORY)
+### Compaction Recovery (MANDATORY)
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
@@ -64,7 +64,7 @@ After compaction, if memory has `sdd/*/active-workflow` observations starting wi
 
 If no `active-workflow` marker is found, do nothing.
 
-## Memory Protocols
+### Memory Protocols
 
 When saving an observation, use this structure:
 
@@ -72,7 +72,7 @@ When saving an observation, use this structure:
 - **type**: `bugfix` | `decision` | `architecture` | `discovery` | `pattern` | `config` | `preference`
 - **content**: What was done, Why, Where (files affected), Learned (gotchas)
 
-## Engram Availability Guard
+### Engram Availability Guard
 
 Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP server that may not be installed or configured. All engram operations MUST follow the availability guard pattern:
 
@@ -91,6 +91,6 @@ Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP se
 3. If tool succeeds -> use the result normally
 ```
 
-## Session close protocol (mandatory)
+### Session close protocol (mandatory)
 
 Before ending a session, call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.

--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -14,6 +14,22 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
+### Output Discipline
+
+User-facing text is for decisions, summaries, and blockers — not for narrating internal mechanics. The user sees tool calls already; they don't need narration on top.
+
+**Do NOT output**:
+- Phase mechanics: "loading the orchestrator", "reading the playbook", "creating the artifact directory", "saving the active-workflow marker", "now running the gate", "launching the sub-agent"
+- The scope check enumeration — compute it silently and act on the result
+- Status updates that paraphrase what the next tool call will do
+
+**DO output**:
+- Questions that require user input (the PRD gate, post-phase decisions)
+- Phase summaries from sub-agent envelopes — condensed, after parsing
+- Errors, blockers, or unexpected state that requires user attention
+
+Default: silence + tools. If your next sentence would be "I am about to do X" or "Let me Y", just do X/Y. The diff is the work; words are only when the user needs to choose or know something they couldn't infer.
+
 ### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**

--- a/workflows/sdd/REGISTRY.copilot.md
+++ b/workflows/sdd/REGISTRY.copilot.md
@@ -1,4 +1,4 @@
-## Orchestrator role
+### Orchestrator role
 
 When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent invocations via `@<sub-agent>` natural-language @-mention, questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -6,7 +6,7 @@ You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git co
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
-## Language Matching
+### Language Matching
 
 Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
 
@@ -14,7 +14,7 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
-## Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
+### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**
 
@@ -36,21 +36,21 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 **How to offer**: Ask the user once with two options: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
-## How to Start (MANDATORY)
+### How to Start (MANDATORY)
 
 When SDD is triggered:
 1. Invoke `@sdd-orchestrator` — your full playbook is pre-loaded as a custom agent file at `.github/agents/sdd-orchestrator.agent.md`
 2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
 3. Follow the Orchestrator instructions to delegate to phase sub-agents via `@sdd-{phase}` natural-language invocations.
 
-## Delegation Rules
+### Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER loads phase skills inline — sub-agents do that. ONLY: track state, show summaries, collect decisions, invoke sub-agents via `@<sub-agent>`.
 2. To launch a phase: use `@sdd-{phase}` (e.g., `@sdd-explorer`, `@sdd-planner`, `@sdd-implementer`, `@sdd-reviewer`). Each sub-agent's `.agent.md` file contains its own full instructions.
 3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator agent — NEVER skip it.
 4. Sub-agents return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
-## Compaction Recovery (MANDATORY)
+### Compaction Recovery (MANDATORY)
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
@@ -62,7 +62,7 @@ After compaction, if memory has `sdd/*/active-workflow` observations starting wi
 
 If no `active-workflow` marker is found, do nothing.
 
-## Memory Protocols
+### Memory Protocols
 
 When saving an observation, use this structure:
 
@@ -70,7 +70,7 @@ When saving an observation, use this structure:
 - **type**: `bugfix` | `decision` | `architecture` | `discovery` | `pattern` | `config` | `preference`
 - **content**: What was done, Why, Where (files affected), Learned (gotchas)
 
-## Engram Availability Guard
+### Engram Availability Guard
 
 Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP server that may not be installed or configured. All engram operations MUST follow the availability guard pattern:
 
@@ -89,6 +89,6 @@ Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP se
 3. If tool succeeds -> use the result normally
 ```
 
-## Session close protocol (mandatory)
+### Session close protocol (mandatory)
 
 Before ending a session, call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.

--- a/workflows/sdd/REGISTRY.copilot.md
+++ b/workflows/sdd/REGISTRY.copilot.md
@@ -1,8 +1,8 @@
 ## Orchestrator role
 
-When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent invocations via `@<sub-agent>` natural-language @-mention, questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
-You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, load `sdd-{phase}` skills inline.
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
@@ -34,29 +34,27 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 - The user explicitly says "just do it" / "skip SDD" / "quick fix"
 - Pure questions or research (no implementation)
 
-**How to offer**: Use `AskUserQuestion` — NEVER suggest SDD as plain text: **Start SDD (explore phase)** / **Skip SDD, just do it**
+**How to offer**: Ask the user once with two options: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
 ## How to Start (MANDATORY)
 
 When SDD is triggered:
-1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
+1. Invoke `@sdd-orchestrator` — your full playbook is pre-loaded as a custom agent file at `.github/agents/sdd-orchestrator.agent.md`
 2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
-3. Follow the Orchestrator instructions to launch sub-agents via the `Agent` tool
-
-**Do NOT** use `Task()` or call `Skill("sdd-explore")`, `Skill("sdd-plan")`, etc. directly — sub-agent skills are preloaded via `skills:` frontmatter. Launch sub-agents with `Agent(subagent_type: 'sdd-{phase}', prompt: '<dynamic context only>')`.
+3. Follow the Orchestrator instructions to delegate to phase sub-agents via `@sdd-{phase}` natural-language invocations.
 
 ## Delegation Rules
 
-1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Agent`.
-2. To launch a phase: use `Agent(subagent_type: 'sdd-{phase}')` — skills are preloaded via frontmatter, pass ONLY dynamic context in the prompt (project path, change name, artifact dir, phase-specific data).
-3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator playbook — NEVER skip it.
-4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
+1. The orchestrator NEVER reads/writes code and NEVER loads phase skills inline — sub-agents do that. ONLY: track state, show summaries, collect decisions, invoke sub-agents via `@<sub-agent>`.
+2. To launch a phase: use `@sdd-{phase}` (e.g., `@sdd-explorer`, `@sdd-planner`, `@sdd-implementer`, `@sdd-reviewer`). Each sub-agent's `.agent.md` file contains its own full instructions.
+3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator agent — NEVER skip it.
+4. Sub-agents return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
 ## Compaction Recovery (MANDATORY)
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
-1. Re-load `Skill("sdd-orchestrator")` and read its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
+1. Re-invoke `@sdd-orchestrator`. The agent file contains the full playbook including the recovery reference at `{WORKFLOW_DIR}/_shared/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
 3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
 4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.

--- a/workflows/sdd/REGISTRY.copilot.md
+++ b/workflows/sdd/REGISTRY.copilot.md
@@ -14,6 +14,22 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
+### Output Discipline
+
+User-facing text is for decisions, summaries, and blockers — not for narrating internal mechanics. The user sees tool calls already; they don't need narration on top.
+
+**Do NOT output**:
+- Phase mechanics: "loading the orchestrator", "reading the playbook", "creating the artifact directory", "saving the active-workflow marker", "now running the gate", "launching the sub-agent"
+- The scope check enumeration — compute it silently and act on the result
+- Status updates that paraphrase what the next tool call will do
+
+**DO output**:
+- Questions that require user input (the PRD gate, post-phase decisions)
+- Phase summaries from sub-agent envelopes — condensed, after parsing
+- Errors, blockers, or unexpected state that requires user attention
+
+Default: silence + tools. If your next sentence would be "I am about to do X" or "Let me Y", just do X/Y. The diff is the work; words are only when the user needs to choose or know something they couldn't infer.
+
 ### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -10,6 +10,12 @@ You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git co
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
+## Language Mirroring
+
+Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
+
+This applies to the orchestrator, every sub-agent it launches, and every skill invoked from the workflow.
+
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
 ## SDD — Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -1,4 +1,4 @@
-## Orchestrator role
+### Orchestrator role
 
 When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Task()`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -6,7 +6,7 @@ You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git co
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
-## Language Matching
+### Language Matching
 
 Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
 
@@ -14,7 +14,7 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
-## Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
+### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**
 
@@ -36,7 +36,7 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 **How to offer**: Use `AskUserQuestion` — NEVER suggest SDD as plain text: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
-## How to Start (MANDATORY)
+### How to Start (MANDATORY)
 
 When SDD is triggered:
 1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
@@ -46,14 +46,14 @@ When SDD is triggered:
 
 **Do NOT** call sub-agent skills (`Skill("sdd-explore")`, `Skill("sdd-plan")`, etc.) directly — those are loaded BY the sub-agents INSIDE a `Task()`. The orchestrator launches `Task()`, the sub-agent loads the Skill.
 
-## Delegation Rules
+### Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Task()`.
 2. To launch a phase: use `Task()` with prompt that tells the sub-agent to call `Skill("sdd-{phase}")`. See `{WORKFLOW_DIR}/_shared/launch-templates.md` for exact templates.
 3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator playbook — NEVER skip it.
 4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
-## Compaction Recovery (MANDATORY)
+### Compaction Recovery (MANDATORY)
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
@@ -65,7 +65,7 @@ After compaction, if memory has `sdd/*/active-workflow` observations starting wi
 
 If no `active-workflow` marker is found, do nothing.
 
-## Memory Protocols
+### Memory Protocols
 
 When saving an observation, use this structure:
 
@@ -73,7 +73,7 @@ When saving an observation, use this structure:
 - **type**: `bugfix` | `decision` | `architecture` | `discovery` | `pattern` | `config` | `preference`
 - **content**: What was done, Why, Where (files affected), Learned (gotchas)
 
-## Engram Availability Guard
+### Engram Availability Guard
 
 Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP server that may not be installed or configured. All engram operations MUST follow the availability guard pattern:
 
@@ -92,6 +92,6 @@ Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP se
 3. If tool succeeds -> use the result normally
 ```
 
-## Session close protocol (mandatory)
+### Session close protocol (mandatory)
 
 Before ending a session, call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -1,16 +1,12 @@
-> **Agent note — OpenCode and Copilot**: Your SDD Orchestrator instructions are embedded natively (as your system prompt / agent file). Any step below that says "read `ORCHESTRATOR.md` directly" or "re-read `ORCHESTRATOR.md`" does **not** apply to you — skip those steps.
->
-> **Codex and Factory agents**: All instructions below apply in full.
+## Orchestrator role
 
-## SDD Role Invariant — you orchestrate, you do not implement
-
-When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches (`Task` / `Agent` / `@<sub-agent>` per your variant), `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Task()`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
 You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
-## Language Mirroring
+## Language Matching
 
 Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
 
@@ -18,7 +14,7 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
-## SDD — Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
+## Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**
 
@@ -40,28 +36,24 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 **How to offer**: Use `AskUserQuestion` — NEVER suggest SDD as plain text: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
-## SDD — How to Start (MANDATORY)
+## How to Start (MANDATORY)
 
 When SDD is triggered:
-1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly _(Codex/Factory only — OpenCode and Copilot: skip the fallback; Skill() is always available)_
+1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
 2. Read `{WORKFLOW_DIR}/_shared/launch-templates.md` — copy-paste templates for `Task()` calls
 3. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
 4. Follow the Orchestrator instructions to launch sub-agents via `Task()` tool
 
 **Do NOT** call sub-agent skills (`Skill("sdd-explore")`, `Skill("sdd-plan")`, etc.) directly — those are loaded BY the sub-agents INSIDE a `Task()`. The orchestrator launches `Task()`, the sub-agent loads the Skill.
 
-## SDD — Delegation Rules
+## Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Task()`.
 2. To launch a phase: use `Task()` with prompt that tells the sub-agent to call `Skill("sdd-{phase}")`. See `{WORKFLOW_DIR}/_shared/launch-templates.md` for exact templates.
-3. After EVERY sub-agent, execute the Post-Phase Protocol from ORCHESTRATOR.md — NEVER skip it.
+3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator playbook — NEVER skip it.
 4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
-Full orchestrator instructions: {WORKFLOW_DIR}/ORCHESTRATOR.md _(Codex/Factory only)_
-
-### SDD -- Compaction Recovery (MANDATORY — Codex and Factory only)
-
-> **OpenCode and Copilot agents**: Your orchestrator is embedded natively — compaction recovery is handled differently. Skip this section.
+## Compaction Recovery (MANDATORY)
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
@@ -75,27 +67,13 @@ If no `active-workflow` marker is found, do nothing.
 
 ## Memory Protocols
 
-### `mem_save` format
-
 When saving an observation, use this structure:
 
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: `bugfix` | `decision` | `architecture` | `discovery` | `pattern` | `config` | `preference`
 - **content**: What was done, Why, Where (files affected), Learned (gotchas)
 
-### Two-Step Recovery Enforcement (mandatory)
-
-`mem_search` returns **truncated 300-character previews** — never treat search results as complete content. Any engram read that requires full content MUST use the two-step pattern:
-
-1. **Step 1 — Search**: `mem_search(query: "...")` to locate the observation ID and verify it exists.
-2. **Step 2 — Retrieve**: `mem_get_observation(id: <id>)` to get the full, untruncated content.
-
-**Rules:**
-- NEVER use `mem_search` results as the final content — they are previews only.
-- ALWAYS follow up with `mem_get_observation` when you need to read, parse, or act on saved content.
-- If `mem_search` returns no results, there is nothing to retrieve — do not call `mem_get_observation`.
-
-### Engram Availability Guard
+## Engram Availability Guard
 
 Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP server that may not be installed or configured. All engram operations MUST follow the availability guard pattern:
 
@@ -114,6 +92,6 @@ Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP se
 3. If tool succeeds -> use the result normally
 ```
 
-### Session close protocol (mandatory)
+## Session close protocol (mandatory)
 
 Before ending a session, call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -14,6 +14,22 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
+### Output Discipline
+
+User-facing text is for decisions, summaries, and blockers — not for narrating internal mechanics. The user sees tool calls already; they don't need narration on top.
+
+**Do NOT output**:
+- Phase mechanics: "loading the orchestrator", "reading the playbook", "creating the artifact directory", "saving the active-workflow marker", "now running the gate", "launching the sub-agent"
+- The scope check enumeration — compute it silently and act on the result
+- Status updates that paraphrase what the next tool call will do
+
+**DO output**:
+- Questions that require user input (the PRD gate, post-phase decisions)
+- Phase summaries from sub-agent envelopes — condensed, after parsing
+- Errors, blockers, or unexpected state that requires user attention
+
+Default: silence + tools. If your next sentence would be "I am about to do X" or "Let me Y", just do X/Y. The diff is the work; words are only when the user needs to choose or know something they couldn't infer.
+
 ### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**

--- a/workflows/sdd/REGISTRY.opencode.md
+++ b/workflows/sdd/REGISTRY.opencode.md
@@ -1,8 +1,8 @@
 ## Orchestrator role
 
-When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent invocations via `@<sub-agent>` natural-language @-mention, questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
-You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, load `sdd-{phase}` skills inline.
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
@@ -34,29 +34,27 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 - The user explicitly says "just do it" / "skip SDD" / "quick fix"
 - Pure questions or research (no implementation)
 
-**How to offer**: Use `AskUserQuestion` — NEVER suggest SDD as plain text: **Start SDD (explore phase)** / **Skip SDD, just do it**
+**How to offer**: Ask the user once with two options: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
 ## How to Start (MANDATORY)
 
 When SDD is triggered:
-1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
+1. Invoke `@sdd-orchestrator` — your full playbook is pre-loaded as a named agent in `opencode.json`
 2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
-3. Follow the Orchestrator instructions to launch sub-agents via the `Agent` tool
-
-**Do NOT** use `Task()` or call `Skill("sdd-explore")`, `Skill("sdd-plan")`, etc. directly — sub-agent skills are preloaded via `skills:` frontmatter. Launch sub-agents with `Agent(subagent_type: 'sdd-{phase}', prompt: '<dynamic context only>')`.
+3. Follow the Orchestrator instructions to delegate to phase sub-agents via `@sdd-{phase}` natural-language invocations.
 
 ## Delegation Rules
 
-1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Agent`.
-2. To launch a phase: use `Agent(subagent_type: 'sdd-{phase}')` — skills are preloaded via frontmatter, pass ONLY dynamic context in the prompt (project path, change name, artifact dir, phase-specific data).
-3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator playbook — NEVER skip it.
-4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
+1. The orchestrator NEVER reads/writes code and NEVER loads phase skills inline — sub-agents do that. ONLY: track state, show summaries, collect decisions, invoke sub-agents via `@<sub-agent>`.
+2. To launch a phase: use `@sdd-{phase}` (e.g., `@sdd-explorer`, `@sdd-planner`, `@sdd-implementer`, `@sdd-reviewer`). Each named agent has its own instructions and model configured in `opencode.json`.
+3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator agent — NEVER skip it.
+4. Sub-agents return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
 ## Compaction Recovery (MANDATORY)
 
-After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
+After compaction, the OpenCode plugin emits a recovery context block if any active workflow marker exists. When you receive that recovery context:
 
-1. Re-load `Skill("sdd-orchestrator")` and read its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
+1. Re-invoke `@sdd-orchestrator`. The named agent contains the full playbook including the recovery reference at `{WORKFLOW_DIR}/_shared/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
 3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
 4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.

--- a/workflows/sdd/REGISTRY.opencode.md
+++ b/workflows/sdd/REGISTRY.opencode.md
@@ -1,4 +1,4 @@
-## Orchestrator role
+### Orchestrator role
 
 When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent invocations via `@<sub-agent>` natural-language @-mention, questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
@@ -6,7 +6,7 @@ You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git co
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
-## Language Matching
+### Language Matching
 
 Present all user-facing output — questions, status messages, summaries, and artifact prose (PRD body, exploration narrative, plan descriptions, review report) — in the **same language the user used** to initiate the workflow. Internal contract fields stay in English: envelope keys, file names, command names, code, log identifiers, JSON keys.
 
@@ -14,7 +14,7 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
-## Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
+### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**
 
@@ -36,21 +36,21 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 **How to offer**: Ask the user once with two options: **Start SDD (explore phase)** / **Skip SDD, just do it**
 
-## How to Start (MANDATORY)
+### How to Start (MANDATORY)
 
 When SDD is triggered:
 1. Invoke `@sdd-orchestrator` — your full playbook is pre-loaded as a named agent in `opencode.json`
 2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
 3. Follow the Orchestrator instructions to delegate to phase sub-agents via `@sdd-{phase}` natural-language invocations.
 
-## Delegation Rules
+### Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER loads phase skills inline — sub-agents do that. ONLY: track state, show summaries, collect decisions, invoke sub-agents via `@<sub-agent>`.
 2. To launch a phase: use `@sdd-{phase}` (e.g., `@sdd-explorer`, `@sdd-planner`, `@sdd-implementer`, `@sdd-reviewer`). Each named agent has its own instructions and model configured in `opencode.json`.
 3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator agent — NEVER skip it.
 4. Sub-agents return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
-## Compaction Recovery (MANDATORY)
+### Compaction Recovery (MANDATORY)
 
 After compaction, the OpenCode plugin emits a recovery context block if any active workflow marker exists. When you receive that recovery context:
 
@@ -62,7 +62,7 @@ After compaction, the OpenCode plugin emits a recovery context block if any acti
 
 If no `active-workflow` marker is found, do nothing.
 
-## Memory Protocols
+### Memory Protocols
 
 When saving an observation, use this structure:
 
@@ -70,7 +70,7 @@ When saving an observation, use this structure:
 - **type**: `bugfix` | `decision` | `architecture` | `discovery` | `pattern` | `config` | `preference`
 - **content**: What was done, Why, Where (files affected), Learned (gotchas)
 
-## Engram Availability Guard
+### Engram Availability Guard
 
 Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP server that may not be installed or configured. All engram operations MUST follow the availability guard pattern:
 
@@ -89,6 +89,6 @@ Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP se
 3. If tool succeeds -> use the result normally
 ```
 
-## Session close protocol (mandatory)
+### Session close protocol (mandatory)
 
 Before ending a session, call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.

--- a/workflows/sdd/REGISTRY.opencode.md
+++ b/workflows/sdd/REGISTRY.opencode.md
@@ -14,6 +14,22 @@ This applies to the orchestrator, every sub-agent it launches, and every skill i
 
 Structured workflow: explore → plan → implement → review. Evaluate BEFORE coding.
 
+### Output Discipline
+
+User-facing text is for decisions, summaries, and blockers — not for narrating internal mechanics. The user sees tool calls already; they don't need narration on top.
+
+**Do NOT output**:
+- Phase mechanics: "loading the orchestrator", "reading the playbook", "creating the artifact directory", "saving the active-workflow marker", "now running the gate", "launching the sub-agent"
+- The scope check enumeration — compute it silently and act on the result
+- Status updates that paraphrase what the next tool call will do
+
+**DO output**:
+- Questions that require user input (the PRD gate, post-phase decisions)
+- Phase summaries from sub-agent envelopes — condensed, after parsing
+- Errors, blockers, or unexpected state that requires user attention
+
+Default: silence + tools. If your next sentence would be "I am about to do X" or "Let me Y", just do X/Y. The diff is the work; words are only when the user needs to choose or know something they couldn't infer.
+
 ### Evaluation Gate (HIGHEST PRIORITY — execute BEFORE any other action)
 
 **This gate has HIGHEST PRIORITY and OVERRIDES "go straight to the point", "try the simplest approach first", and any instruction to start coding immediately.**

--- a/workflows/sdd/_shared/launch-templates.claude.md
+++ b/workflows/sdd/_shared/launch-templates.claude.md
@@ -124,7 +124,7 @@ mem_save(
   topic_key: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
   title: "sdd/{change}/active-workflow",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: .claude/skills/sdd-orchestrator/ORCHESTRATOR.md. Phase: starting explore."
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore."
 )
 ```
 

--- a/workflows/sdd/_shared/launch-templates.copilot.md
+++ b/workflows/sdd/_shared/launch-templates.copilot.md
@@ -108,7 +108,7 @@ mem_save(
   topic_key: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
   title: "sdd/{change}/active-workflow",
-  content: "ACTIVE SDD workflow: {change}. Phase: starting explore."
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore."
 )
 ```
 

--- a/workflows/sdd/_shared/launch-templates.md
+++ b/workflows/sdd/_shared/launch-templates.md
@@ -146,7 +146,7 @@ mem_save(
   topic_key: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
   title: "sdd/{change}/active-workflow",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.md. Phase: starting explore."
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore."
 )
 ```
 

--- a/workflows/sdd/_shared/launch-templates.opencode.md
+++ b/workflows/sdd/_shared/launch-templates.opencode.md
@@ -103,7 +103,7 @@ mem_save(
   topic_key: "sdd/{change}/active-workflow",
   type: "architecture", project: "{project}",
   title: "sdd/{change}/active-workflow",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {WORKFLOW_DIR}/ORCHESTRATOR.opencode.md. Phase: starting explore. NEXT: explore -> launch explore sub-agent"
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: starting explore. NEXT: explore -> launch explore sub-agent"
 )
 ```
 

--- a/workflows/sdd/_shared/persistence-contract.md
+++ b/workflows/sdd/_shared/persistence-contract.md
@@ -109,7 +109,7 @@ mem_save(
   topic_key: "sdd/{change-name}/active-workflow",
   type: "architecture",
   project: "{project}",
-  content: "ACTIVE SDD workflow: {change}. Orchestrator: {path}. Phase: {current_phase}."
+  content: "ACTIVE SDD workflow: {change}. Workdir: .sdd/{change}/. Phase: {current_phase}."
 )
 ```
 

--- a/workflows/sdd/sdd-explore/SKILL.md
+++ b/workflows/sdd/sdd-explore/SKILL.md
@@ -14,10 +14,11 @@ Token budget for the final selection: target **50–80k tokens** across files + 
 
 > **Incremental writing**: never accumulate all findings and write `exploration.md` in one giant `Write` at the end — that exceeds output token limits and loops the agent. Initialise the file with the template, then append/update sections via `Edit` after every 3–5 files discovered.
 
-1. **Create the session file** with the template
+1. **Read `prd.md` if present**, then create the session file with the template
+   - If `.sdd/{change-name}/prd.md` exists, read it FIRST as the source of intent (Problem / Solution / User Stories / Out of Scope / Further Notes). Use it to seed `## Objective` and `### Task:` directly. The PRD is the WHAT; exploration.md is the WHERE.
    - Path: `.sdd/{change-name}/exploration.md`
    - Template: [templates/exploration_template.md](templates/exploration_template.md) (do not omit any section)
-   - Use `Write` once to seed the file with placeholders. Fill `## Objective` immediately if the task is clear from the prompt.
+   - Use `Write` once to seed the file with placeholders. Fill `## Objective` immediately if the task is clear from the prompt or PRD.
 
 2. **Get Jira ticket details** (only when a ticket ID was provided)
    - Tool: `mcp__atlassian__jira_get_issue` with `{"issue_key": "<ticket_id>"}`

--- a/workflows/sdd/sdd-orchestrator/SKILL.md
+++ b/workflows/sdd/sdd-orchestrator/SKILL.md
@@ -24,16 +24,9 @@ allowed-tools:
   - Skill(sdd-plan)
   - Skill(sdd-implement)
   - Skill(sdd-review)
+  - Skill(write-a-prd)
   - Skill(git-commit)
   - Skill(git-pull-request)
   - Task
   - AskUserQuestion
 ---
-
-# SDD Orchestrator
-
-Coordinates the SDD (Spec-Driven Development) workflow via sub-agents: explore → plan → implement → review.
-
-## Instructions
-
-Read `{WORKFLOW_DIR}/ORCHESTRATOR.md` FIRST and COMPLETELY — this is your full playbook.

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -28,7 +28,7 @@ Create the implementation plan for the next phase. The plan file is your entire 
 
 ## Main Flow
 
-1. **Read exploration context** from `.sdd/{change-name}/exploration.md`.
+1. **Read context** from `.sdd/{change-name}/exploration.md`. If `.sdd/{change-name}/prd.md` exists, read it too — PRD is the WHAT/WHY (user perspective), exploration.md is the WHERE (codebase context); the plan combines both into the HOW.
 
    If `exploration.md` is missing or incomplete, recover via the two-step pattern in `_shared/persistence-contract.md`. If neither file nor engram has it, return envelope with `status: blocked`.
 


### PR DESCRIPTION
Closes #42.

## Summary

Adds an opt-in PRD-drafting gate (Step 0b) between the active-workflow marker and the explore phase. Catches poor context before burning tokens on exploration. Inspired by [Matt Pocock's `write-a-prd` skill](https://github.com/mattpocock/ai-engineer-workshop-2026-project/blob/main/.claude/skills/write-a-prd/SKILL.md), adapted for SDD.

## Why

When the user's brief is vague or the bound ticket has empty body content, the explorer infers intent from a thin prompt and the planner inherits the thinness. The feature ends up vaguely scoped because the **intent** was never crystallised. The PRD gate forces the user to either confirm "scope is clear" or invest a few minutes drafting a tight intent doc before exploration runs.

## Components

### `skills/write-a-prd/SKILL.md` (new)

A general-purpose skill that drafts a PRD via interactive interview. Three rules + three checkpoints:

**Three rules** (from grill-me):
- One question at a time.
- For each question, propose your recommended answer.
- If the answer lives in the codebase, explore instead of asking.

**Three checkpoints** to bound the interview:
- **Vague-answer pushback (once per branch).** When the user replies "no sé" / "decide tú", give one honest pushback: *"Si tú no lo tienes claro, yo tampoco — la feature va a quedar vagamente implementada. ¿Pensamos juntos una respuesta o lo marco como Ambiguity?"* If still no answer, mark as Ambiguity in `Further Notes` and move on.
- **Periodic stop offer (every ~3 rounds).** *"Tengo todavía N preguntas pendientes, pero con lo resuelto ya se podría arrancar. ¿Sigo o vamos?"*
- **Stop on signal.** "vamos" / "go" / "ya está" / "done" closes the interview.

**SDD-tailored PRD template**:

```
## Problem Statement       ← user's perspective
## Solution                ← user's perspective
## User Stories            ← long numbered list, "As X, I want Y, so that Z"
## Out of Scope            ← what's explicitly excluded
## Further Notes           ← ambiguities, ticket links, deferred decisions
```

**Excluded** from the PRD (kept in `plan.md`, owned by `sdd-plan`):
- Implementation Decisions (modules, interfaces, schema, API contracts)
- Testing Decisions
- File paths and code snippets

PRDs are intent docs that survive refactoring; file paths and code go obsolete fast and don't belong here.

### Step 0b in all four ORCHESTRATOR variants

`ORCHESTRATOR.md`, `ORCHESTRATOR.claude.md`, `ORCHESTRATOR.copilot.md`, `ORCHESTRATOR.opencode.md` get a new section between the active-workflow marker save and the Post-Phase Protocol:

> Compute a 2-line TL;DR. Ask once via `AskUserQuestion`:
> - "Draft a PRD first" — recommended if prompt is short / no ticket / ticket body empty
> - "Skip — scope is clear, go to explore" — recommended if context is rich
>
> If "Draft PRD": invoke `Skill("write-a-prd")` (or `@write-a-prd` for Copilot) with the change-name. Skill persists `.sdd/{change}/prd.md`. Continue to explore.
> If "Skip": continue directly to explore phase.

The skill runs **in the orchestrator's main session context**, not as a sub-agent — user interaction needs the main session, and a sub-agent round-trip per question would cost more tokens than running inline.

### One-line additions to phase skills

- `sdd-explore/SKILL.md` Step 1: read `prd.md` first if it exists; use it to seed `## Objective` / `### Task:` directly. PRD is the WHAT, exploration.md is the WHERE.
- `sdd-plan/SKILL.md` Step 1: read `prd.md` alongside `exploration.md` if it exists. PRD = WHAT/WHY (user perspective), exploration = WHERE (codebase context); plan = HOW.

Both skills degrade gracefully when no PRD exists — behaviour is unchanged for the "Skip" path.

## Files

| File | Δ |
|---|---|
| `skills/write-a-prd/SKILL.md` | NEW (69 lines) |
| `workflows/sdd/ORCHESTRATOR.md` | +13 |
| `workflows/sdd/ORCHESTRATOR.claude.md` | +13 |
| `workflows/sdd/ORCHESTRATOR.copilot.md` | +13 |
| `workflows/sdd/ORCHESTRATOR.opencode.md` | +13 |
| `workflows/sdd/sdd-explore/SKILL.md` | +5 / -2 |
| `workflows/sdd/sdd-plan/SKILL.md` | +2 / -1 |

7 files, +125/-3.

## Why no DevRune renderer changes

The new skill installs through the existing skill-rendering pipeline (drops into `skills/` like any other shared skill). The orchestrator content is consumed verbatim per agent variant — same path as every other audit change. Confirmed by reading the renderer code: no test asserts skill paths or count, no behavioural change needed in renderers.

## Test plan

- [ ] Install the catalog into a test workspace (`devrune sync`). Verify `skills/write-a-prd/SKILL.md` lands in the agent's skill directory and is auto-discovered (e.g. visible in `/skills`).
- [ ] Trigger SDD with a deliberately thin prompt (`/sdd-explore quick-feature`). Confirm Step 0b asks the question with "Draft PRD" recommended.
- [ ] Pick "Draft PRD". Verify the interview runs one question at a time, each with a recommended answer.
- [ ] Answer "no sé" to a question. Verify the pushback fires once and the branch gets marked as Ambiguity if you still don't answer.
- [ ] After ~3 rounds, verify the periodic stop offer appears.
- [ ] Type "vamos" / "go" / "done". Verify `.sdd/{change}/prd.md` is written with the SDD template (no file paths, no implementation/testing sections).
- [ ] Verify the explore phase reads `prd.md` and seeds `## Objective` / `### Task:` from it.
- [ ] Trigger SDD with a rich prompt. Confirm Step 0b recommends "Skip" and the skip path proceeds straight to explore (no PRD created).
- [ ] Trigger `sdd-plan` after explore completes. Verify it reads `prd.md` alongside `exploration.md` (or operates correctly without `prd.md` when none was created).

## Out of scope

- Refactoring `sdd-plan`'s Deep Interview Phase to use the same three rules — possible follow-up.
- Auto-creation of GitHub issue / Jira ticket when no ticket is bound — separate concern (workflow-lifecycle work).