### PR TITLE
feat(sdd): include write-a-prd as workflow dependency

### DIFF
--- a/workflows/sdd/workflow.yaml
+++ b/workflows/sdd/workflow.yaml
@@ -11,6 +11,11 @@ components:
     - sdd-implement
     - sdd-review
     - sdd-orchestrator
+    # write-a-prd lives at catalog/skills/write-a-prd/ (not under this workflow).
+    # The renderer resolves it via the catalog-level fallback so SDD installs
+    # carry it automatically — no manual select needed in devrune.yaml.
+    # The PRD gate in ORCHESTRATOR's "Step 1 — PRD gate" invokes it.
+    - write-a-prd
   entrypoint: "ORCHESTRATOR.md"
   roles:
     - name: sdd-explorer
@@ -78,6 +83,8 @@ components:
     - "Skill(sdd-plan)"
     - "Skill(sdd-implement)"
     - "Skill(sdd-review)"
+    # PRD gate dependency (invoked from ORCHESTRATOR's Step 1)
+    - "Skill(write-a-prd)"
     # Git operations (commit/PR skills)
     - "Bash(git status:*)"
     - "Bash(git -C:*)"


### PR DESCRIPTION
## Summary

Adds \`write-a-prd\` to the SDD workflow's \`components.skills\` (and a matching \`Skill(write-a-prd)\` permission) so the skill is pulled in automatically when users install SDD — no manual entry in \`devrune.yaml\` needed.

## Why

SDD's PRD gate (Step 1 in ORCHESTRATOR) invokes \`Skill(\"write-a-prd\")\` at workflow start. Until now this was an implicit dependency: every user had to remember to add \`write-a-prd\` to their \`devrune.yaml\` package select, or SDD would fail the moment the gate fired.

\`write-a-prd\` lives at \`catalog/skills/write-a-prd/\` — outside the SDD workflow directory — so before [DevRune#65](https://github.com/davidarce/DevRune/pull/65) the workflow couldn't list it. With #65 merged, \`components.skills\` resolves names workflow-internal first and falls back to \`catalog/skills/<name>/\`, making this declaration possible.

## Changes

- \`workflows/sdd/workflow.yaml\`:
  - Add \`- write-a-prd\` to \`components.skills\`
  - Add \`Skill(write-a-prd)\` to \`permissions\`

## Dependency

Requires DevRune#65 (catalog-level skill resolution). The PR linked above adds the resolver. **Do not merge this PR until #65 is merged and a release is cut** — otherwise users on the current binary will hit a \"skill not a workflow subdir\" error.

## Test plan

- [ ] Wait for DevRune#65 to merge + release
- [ ] Update DevRune install to the new version
- [ ] Re-install on a workspace whose \`devrune.yaml\` does NOT explicitly select \`write-a-prd\`
- [ ] Verify \`.claude/skills/write-a-prd/SKILL.md\` (and \`.agents/skills/write-a-prd/SKILL.md\` for OpenCode) appear after install
- [ ] Run an SDD workflow with thin context, confirm the PRD gate fires and \`write-a-prd\` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)