### PR TITLE
feat(sdd): tighten adviser coverage, review-ok auto-flow (#49)

### DIFF
--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -70,3 +70,4 @@ Do NOT include file paths, code snippets, module sketches, or implementation/tes
 - No file paths, code snippets, module sketches, or testing details in the document.
 - Ambiguities the user could not resolve are listed in Further Notes (not silently dropped).
 - Did NOT submit external issues or call external services.
+- Did NOT emit handoff narration after persisting the PRD; the host's main loop resumes immediately when this skill returns.

--- a/skills/write-a-prd/SKILL.md
+++ b/skills/write-a-prd/SKILL.md
@@ -70,4 +70,3 @@ Do NOT include file paths, code snippets, module sketches, or implementation/tes
 - No file paths, code snippets, module sketches, or testing details in the document.
 - Ambiguities the user could not resolve are listed in Further Notes (not silently dropped).
 - Did NOT submit external issues or call external services.
-- Did NOT emit handoff narration after persisting the PRD; the host's main loop resumes immediately when this skill returns.

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -219,7 +219,7 @@ After review completes, behavior depends on status:
 - `warning` → ask: **Commit anyway** / **Fix issues first** / **Done**
 - `failed` → ask: **Fix issues** / **Done** (NO commit option)
 
-The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here. When "Fix issues": delegate fixes via `Agent(subagent_type: 'sdd-implementer', ...)`, then auto-launch review again.
+When "Fix issues": delegate fixes via `Agent(subagent_type: 'sdd-implementer', ...)`, then auto-launch review again.
 
 On Abort at any status: clear `awaiting_user_decision`; write marker ABORTED.
 

--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -94,7 +94,7 @@ After saving the active-workflow marker and before launching the explore sub-age
 3. **If context is thin**: ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
-4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. **When the skill returns, auto-launch the explore sub-agent immediately** — no ask, no narration, no wait. The user's choice in step 3 covers the whole PRD→explore arc.
 5. **If "Proceed anyway"**: continue directly to the explore phase.
 
 The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
@@ -211,14 +211,19 @@ A large plan exhausts a single sub-agent's context. The orchestrator drives wave
 
 ## Post-Review Fix Cycle
 
-After review completes, options depend on status:
-- `ok` → **Commit** (via `git-commit` skill) / **Done (no commit)**
-- `warning` → **Commit anyway** / **Fix issues first** / **Done**
-- `failed` → **Fix issues** / **Done** (NO commit option)
+After review completes, behavior depends on status:
 
-When user chooses "Commit": invoke `Skill("git-commit")`. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here. When "Fix issues": delegate fixes via `Agent(subagent_type: 'sdd-implementer', ...)`, then auto-launch review again.
+- `ok` → **Auto-commit** (invoke `Skill("git-commit")` immediately, no ask) → **Auto-PR** (invoke `Skill("git-pull-request")` immediately, no ask) → write marker COMPLETED. Zero user prompts on the happy path.
+  - If commit fails: set `awaiting_user_decision=post-review-commit-retry` in state.yaml; ask **Retry commit** / **Abort** — marker stays ACTIVE.
+  - If PR fails: set `awaiting_user_decision=post-review-pr-retry` in state.yaml; ask **Retry PR** / **Abort** — marker stays ACTIVE.
+- `warning` → ask: **Commit anyway** / **Fix issues first** / **Done**
+- `failed` → ask: **Fix issues** / **Done** (NO commit option)
 
-On workflow completion with commit: offer `Skill("git-pull-request")`.
+The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here. When "Fix issues": delegate fixes via `Agent(subagent_type: 'sdd-implementer', ...)`, then auto-launch review again.
+
+On Abort at any status: clear `awaiting_user_decision`; write marker ABORTED.
+
+Terminal states: COMPLETED (success) and ABORTED (gave up) — no partial-success terminal.
 
 On completion or abort, clear the marker:
 ```

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -86,7 +86,7 @@ After saving the active-workflow marker and before invoking `@sdd-explorer`, ass
 3. **If context is thin**: ask the user once:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
-4. **If "Draft PRD"**: invoke the skill `write-a-prd` with the change-name. The skill runs the interview and persists `.sdd/{change-name}/prd.md`. Continue to the explore invocation when it returns.
+4. **If "Draft PRD"**: invoke the skill `write-a-prd` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. **When the skill returns, auto-launch the explore sub-agent immediately** — no ask, no narration, no wait. The user's choice in step 3 covers the whole PRD→explore arc.
 5. **If "Proceed anyway"**: invoke `@sdd-explorer` directly.
 
 The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `@sdd-explorer` and `@sdd-planner` consume `prd.md` only when present; behaviour is unchanged when it isn't.
@@ -198,15 +198,22 @@ A large plan exhausts a single sub-agent's context. The orchestrator drives wave
 
 ## Post-Review Fix Cycle
 
-After review completes, options depend on status:
-- `ok` -> **Commit** (via `@git-commit` agent) / **Done (no commit)**
-- `warning` -> **Commit anyway** (via `@git-commit` agent) / **Fix issues first** / **Done**
-- `failed` -> **Fix issues** / **Done** (NO commit option)
+After review completes, actions depend on status:
 
-When user chooses "Commit": invoke the `@git-commit` agent — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
+- `ok` → **Auto-commit** (invoke `@git-commit` agent immediately, no ask) → **Auto-PR** (invoke
+  `@git-pull-request` agent immediately, no ask) → write marker COMPLETED. No user prompts.
+  - If commit fails: set `awaiting_user_decision=post-review-commit-retry` in state.yaml;
+    ask **Retry commit** / **Abort** — marker stays ACTIVE.
+  - If PR fails: set `awaiting_user_decision=post-review-pr-retry` in state.yaml;
+    ask **Retry PR** / **Abort** — marker stays ACTIVE.
+- `warning` → ask: **Commit anyway** (via `@git-commit` agent) / **Fix issues first** / **Done**
+- `failed` → ask: **Fix issues** / **Done** (NO commit option)
+
+When user chooses "Commit" (warning path): invoke the `@git-commit` agent — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
 When user chooses "Fix issues": delegate fixes to a sub-agent (orchestrator NEVER fixes code), then auto-launch review again.
 
-On workflow completion with commit: offer PR creation via the `@git-pull-request` agent.
+On Abort at any status: clear `awaiting_user_decision`; write marker ABORTED.
+Terminal states: COMPLETED (success) and ABORTED (gave up) — no partial-success terminal.
 
 On workflow completion or abort, clear the marker:
 ```

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -209,7 +209,7 @@ After review completes, actions depend on status:
 - `warning` → ask: **Commit anyway** (via `@git-commit` agent) / **Fix issues first** / **Done**
 - `failed` → ask: **Fix issues** / **Done** (NO commit option)
 
-When user chooses "Commit" (warning path): invoke the `@git-commit` agent — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
+When user chooses "Commit" (warning path): invoke the `@git-commit` agent — do NOT run git commands directly.
 When user chooses "Fix issues": delegate fixes to a sub-agent (orchestrator NEVER fixes code), then auto-launch review again.
 
 On Abort at any status: clear `awaiting_user_decision`; write marker ABORTED.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -213,7 +213,7 @@ After review completes, behavior depends on status:
 - `warning` → ask: **Commit anyway** (via `git-commit` skill) / **Fix issues first** / **Done**
 - `failed` → ask: **Fix issues** / **Done** (NO commit option)
 
-When user chooses "Commit anyway" or "Fix issues": invoke `Skill("git-commit")` — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
+When user chooses "Commit anyway": invoke `Skill("git-commit")` — do NOT run git commands directly.
 When user chooses "Fix issues": delegate fixes to a sub-agent (orchestrator NEVER fixes code), then auto-launch review again.
 
 On Abort at any status: clear `awaiting_user_decision`; write marker `ABORTED`.

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -78,7 +78,7 @@ After saving the active-workflow marker and before launching the explore sub-age
 3. **If context is thin**: ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
-4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. **When the skill returns, auto-launch the explore sub-agent immediately** — no ask, no narration, no wait. The user's choice in step 3 covers the whole PRD→explore arc.
 5. **If "Proceed anyway"**: continue directly to the explore phase.
 
 The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
@@ -205,15 +205,19 @@ A large plan exhausts a single sub-agent's context. The orchestrator drives wave
 
 ## Post-Review Fix Cycle
 
-After review completes, options depend on status:
-- `ok` -> **Commit** (via `git-commit` skill) / **Done (no commit)**
-- `warning` -> **Commit anyway** (via `git-commit` skill) / **Fix issues first** / **Done**
-- `failed` -> **Fix issues** / **Done** (NO commit option)
+After review completes, behavior depends on status:
 
-When user chooses "Commit": invoke `Skill("git-commit")` — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
+- `ok` → **Auto-commit** (invoke `Skill("git-commit")` immediately, no ask) → **Auto-PR** (invoke `Skill("git-pull-request")` immediately, no ask) → write marker `COMPLETED`. Zero user prompts on the happy path.
+  - If commit fails: set `awaiting_user_decision=post-review-commit-retry` in `state.yaml`; ask **Retry commit** / **Abort** — marker stays `ACTIVE`.
+  - If PR fails: set `awaiting_user_decision=post-review-pr-retry` in `state.yaml`; ask **Retry PR** / **Abort** — marker stays `ACTIVE`.
+- `warning` → ask: **Commit anyway** (via `git-commit` skill) / **Fix issues first** / **Done**
+- `failed` → ask: **Fix issues** / **Done** (NO commit option)
+
+When user chooses "Commit anyway" or "Fix issues": invoke `Skill("git-commit")` — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
 When user chooses "Fix issues": delegate fixes to a sub-agent (orchestrator NEVER fixes code), then auto-launch review again.
 
-On workflow completion with commit: offer PR creation via `Skill("git-pull-request")`.
+On Abort at any status: clear `awaiting_user_decision`; write marker `ABORTED`.
+Terminal states: `COMPLETED` (success) and `ABORTED` (gave up) — marker is `COMPLETED` only after both commit and PR succeed.
 
 On workflow completion or abort, clear the marker:
 ```

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -78,7 +78,7 @@ After saving the active-workflow marker and before launching the explore sub-age
 3. **If context is thin**: ask once via `AskUserQuestion`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
-4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. Continue to explore when it returns.
+4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the interview in your context and persists `.sdd/{change-name}/prd.md`. **When the skill returns, auto-launch the explore sub-agent immediately** — no ask, no narration, no wait. The user's choice in step 3 covers the whole PRD→explore arc.
 5. **If "Proceed anyway"**: continue directly to the explore phase.
 
 The PRD is opt-in for thin contexts only — never force it, never offer it when the user already gave you enough. `sdd-explore` and `sdd-plan` consume `prd.md` only when present; behaviour is unchanged when it isn't.
@@ -186,15 +186,18 @@ A large plan exhausts a single sub-agent's context. The orchestrator drives wave
 
 ## Post-Review Fix Cycle
 
-After review completes, options depend on status:
-- `ok` -> **Commit** (via `git-commit` skill) / **Done (no commit)**
-- `warning` -> **Commit anyway** (via `git-commit` skill) / **Fix issues first** / **Done**
-- `failed` -> **Fix issues** / **Done** (NO commit option)
+After review completes, behavior depends on status:
 
-When user chooses "Commit": invoke `Skill("git-commit")` — do NOT run git commands directly. The branch was set up at workflow start (see "First Sub-Agent of a New Workflow"), so no branch validation is needed here.
+- `ok` → **Auto-commit** (invoke `Skill("git-commit")` immediately, no ask) → **Auto-PR** (invoke `Skill("git-pull-request")` immediately, no ask) → write marker COMPLETED. Zero user prompts on the happy path.
+  - If commit fails: set `awaiting_user_decision=post-review-commit-retry` in state.yaml; ask **Retry commit** / **Abort** — marker stays ACTIVE.
+  - If PR fails: set `awaiting_user_decision=post-review-pr-retry` in state.yaml; ask **Retry PR** / **Abort** — marker stays ACTIVE.
+- `warning` → ask: **Commit anyway** (via `Skill("git-commit")`) / **Fix issues first** / **Done**
+- `failed` → ask: **Fix issues** / **Done** (NO commit option)
+
 When user chooses "Fix issues": delegate fixes to a sub-agent (orchestrator NEVER fixes code), then auto-launch review again.
+On Abort at any status: clear `awaiting_user_decision`; write marker ABORTED.
 
-On workflow completion with commit: offer PR creation via `Skill("git-pull-request")`.
+Terminal states: COMPLETED (both commit and PR succeeded) and ABORTED (gave up) — no partial-success terminal state.
 
 On workflow completion or abort, clear the marker:
 ```

--- a/workflows/sdd/_shared/persistence-contract.md
+++ b/workflows/sdd/_shared/persistence-contract.md
@@ -60,6 +60,15 @@ guidance_round: {N}        # Optional. Increments per advisor consultation cycle
 plan_review_round: {N}     # Optional. Increments per Crit review round.
 crit_completed: true       # Optional. Set when Crit approves the plan (no unresolved comments).
 review_round: {N}          # Optional. Increments per post-review fix cycle.
+
+# Optional — set by orchestrator during review→completion auto-flow
+commit_completed: true          # boolean; set after git-commit skill returns ok
+commit_sha: "<git-sha>"         # string; set alongside commit_completed for audit + idempotence
+awaiting_user_decision: "<enum>" # string; set when auto-flow stops at a failure ask
+                                  # valid values:
+                                  #   post-review-commit-retry  (commit failed)
+                                  #   post-review-pr-retry      (PR failed, commit ok)
+                                  # cleared when the user answers (Retry or Abort)
 ```
 
 **Explicitly NOT in state.yaml**:
@@ -82,6 +91,19 @@ When the orchestrator resumes after compaction:
 2. Compute available artifacts: `ls .sdd/{change}/*.md`.
 3. If `current_phase: implement` and `plan.md` exists, count `[X]` vs `[ ]` markers to determine batch progress.
 4. Resume from the next pipeline phase (or the next pending batch within `implement`).
+
+### Recovery Semantics — Review→Completion Auto-Flow
+
+When `current_phase: review` and `status: ok`, the orchestrator applies these rules in order:
+
+1. **`awaiting_user_decision == post-review-commit-retry`**: the auto-flow stopped at a commit failure. Resume by surfacing the commit failure ask (**Retry commit / Abort**). Do NOT re-run the commit automatically.
+2. **`awaiting_user_decision == post-review-pr-retry`**: `commit_completed` is `true`; the commit already succeeded. Skip the commit step entirely and surface the PR failure ask (**Retry PR / Abort**).
+3. **`commit_completed == true` and `awaiting_user_decision` is absent**: commit already done; the auto-flow was interrupted after commit but before PR. Proceed directly to auto-PR (no re-commit).
+4. **Neither `commit_completed` nor `awaiting_user_decision` is present**: normal entry — follow the standard auto-commit → auto-PR → COMPLETED path.
+
+**Clearing rules**:
+- On Abort at any point: clear `awaiting_user_decision` from state.yaml; write marker `ABORTED`.
+- On successful PR: clear `awaiting_user_decision`, `commit_completed`, and `commit_sha`; write marker `COMPLETED`.
 
 ### Optional Engram State Save
 

--- a/workflows/sdd/sdd-plan/SKILL.md
+++ b/workflows/sdd/sdd-plan/SKILL.md
@@ -52,6 +52,8 @@ Create the implementation plan for the next phase. The plan file is your entire 
 
    <!-- ADVISOR_TABLE_PLACEHOLDER -->
 
+   **Adviser coverage rule**: for each adviser in the registry (identified by its SKILL.md `description` frontmatter), evaluate whether the plan's contracts, tasks, or affected layers fall under that adviser's described domain. If the domain overlap is clear, that adviser MUST appear in Team Selection. Skip is allowed only with an explicit rationale that quotes or references the adviser's `description` frontmatter text — boilerplate like "not relevant" is rejected by the Detail Quality Gate. Err toward inclusion when the overlap is borderline.
+
    If no advisor skills are listed above, skip steps 5 and 7 and proceed to step 6.
 
    Process:
@@ -100,6 +102,7 @@ Create the implementation plan for the next phase. The plan file is your entire 
    3. **Before/After Analysis** — modification tasks show current → proposed state in Section 2's "Before/After Analysis".
    4. **Testable Checkpoints** — every phase Checkpoint lists specific verifiable criteria.
    5. **PRD coverage** (only when `prd.md` exists for this change) — for **every** User Story / requirement listed in `prd.md`, at least one task in `plan.md` must demonstrably implement it. Walk the PRD top-to-bottom: for each US/requirement, name the TXXX task(s) that cover it. If any US has zero matching tasks, it's a gap — add the missing task(s) BEFORE continuing. Document the mapping in `## 4. Clarifications` as `- **PRD coverage**: US1 → T003,T007 / US2 → T011 / US3 → T012-T014`. The reviewer will catch the gap if you don't, but late-stage rework is more expensive than fixing it here.
+   6. **Adviser coverage** — every installed adviser whose described domain overlaps this plan's contracts or tasks appears in Team Selection, or has an explicit skip rationale that quotes or references the adviser's `description` frontmatter text. Boilerplate ("not relevant", "out of scope") without a domain reference fails this check.
 
    If any check fails, fill the missing detail before continuing.
 


### PR DESCRIPTION
## Summary

Three workflow autonomy improvements to reduce orchestrator interruptions and ensure the adviser registry is actually used. Closes #49.

- **Adviser coverage gate** (`sdd-plan/SKILL.md`): paso 5 now requires advisers whose described domain overlaps the plan; Detail Quality Gate rejects boilerplate skip rationales. Rule is semantic against each adviser's `description` frontmatter — tech-agnostic, not keyword-matching.
- **Skill-in-host handoff** (`write-a-prd/SKILL.md`): Self-Check forbids handoff narration after persisting the PRD. Self-contained bullet, no shared file (per crit round 1 — overengineering avoided).
- **Review ok = natural workflow completion** (4 ORCHESTRATOR variants): `ok` auto-commits, auto-PRs, marks `COMPLETED` with no asks. commit/PR failures ask **Retry / Abort** symmetrically. Only two terminal states (`COMPLETED`, `ABORTED`) — no partial-success.
- **PRD gate auto-continue** (4 ORCHESTRATOR variants): step 4 explicitly says "auto-launch explore immediately — no ask, no narration, no wait" when `write-a-prd` returns.
- **state.yaml schema** (`_shared/persistence-contract.md`): adds optional `commit_completed`, `commit_sha`, `awaiting_user_decision` fields with documented Recovery Semantics. Makes the auto-flow safe across compaction boundaries.

## Process

- Planned via SDD workflow (`.sdd/sdd-workflow-autonomy/`).
- `architect-advisor` consulted in plan phase: confirmed shared-file drop and symmetric Retry/Abort design (no partial-success terminal).
- 4 rounds of crit review, all comments resolved.
- Token cost estimate posted in crit thread: ~820 tokens net per workflow (~0.5–1.6% over baseline), offset by fewer crit rounds when adviser selection lands correctly first try.

## Test Plan

- [ ] Behavioral spec inspection across all 4 ORCHESTRATOR variants (per-variant consistency)
- [ ] grep `"Skip PR (mark COMPLETED)"` returns 0 matches across the catalog
- [ ] `sdd-plan/SKILL.md` paso 5 + DQG check 6 read cleanly
- [ ] `write-a-prd/SKILL.md` Self-Check has 7 bullets, last is principle-based
- [ ] `_shared/persistence-contract.md` Recovery Semantics covers all 4 cases
- [ ] Run a fresh SDD workflow end-to-end after merge: confirm no commit/PR ask on review ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)