### PR TITLE
fix(workflows/sdd): align OpenCode orchestrator on Task() + WORKFLOW_SUBAGENT_ADVISOR

### DIFF
--- a/workflows/sdd/REGISTRY.opencode.md
+++ b/workflows/sdd/REGISTRY.opencode.md
@@ -1,6 +1,6 @@
 ### Orchestrator role
 
-When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent invocations via `@<sub-agent>` natural-language @-mention, questions to the user, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
+When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via the `Task` tool with `subagent_type: '{WORKFLOW_SUBAGENT_*}'`, questions to the user via `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
 You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, load `sdd-{phase}` skills inline.
 
@@ -78,14 +78,14 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 ### How to Start (MANDATORY)
 
 When SDD is triggered:
-1. Invoke `@sdd-orchestrator` — your full playbook is pre-loaded as a named agent in `opencode.json`
+1. The `sdd-orchestrator` agent is the active primary agent — its full playbook is loaded from `opencode.json`. You ARE the orchestrator; do not try to re-invoke yourself.
 2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
-3. Follow the Orchestrator instructions to delegate to phase sub-agents via `@sdd-{phase}` natural-language invocations.
+3. Follow the Orchestrator instructions to delegate to phase sub-agents via the `Task` tool, using `subagent_type: '{WORKFLOW_SUBAGENT_<PHASE>}'` (the phase placeholders resolve to the agent names declared in `opencode.json`).
 
 ### Delegation Rules
 
-1. The orchestrator NEVER reads/writes code and NEVER loads phase skills inline — sub-agents do that. ONLY: track state, show summaries, collect decisions, invoke sub-agents via `@<sub-agent>`.
-2. To launch a phase: use `@sdd-{phase}` (e.g., `@sdd-explorer`, `@sdd-planner`, `@sdd-implementer`, `@sdd-reviewer`). Each named agent has its own instructions and model configured in `opencode.json`.
+1. The orchestrator NEVER reads/writes code and NEVER loads phase skills inline — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via the `Task` tool.
+2. To launch a phase: call `Task(subagent_type: '{WORKFLOW_SUBAGENT_<PHASE>}', ...)`. Concrete subagent types per phase are listed in `{WORKFLOW_DIR}/_shared/launch-templates.md`. Each agent has its own model and instructions configured in `opencode.json`.
 3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator agent — NEVER skip it.
 4. Sub-agents return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
@@ -93,7 +93,7 @@ When SDD is triggered:
 
 After compaction, the OpenCode plugin emits a recovery context block if any active workflow marker exists. When you receive that recovery context:
 
-1. Re-invoke `@sdd-orchestrator`. The named agent contains the full playbook including the recovery reference at `{WORKFLOW_DIR}/_shared/recovery.md`.
+1. You are still the `sdd-orchestrator` agent — the full playbook is already in your prompt, including the recovery reference at `{WORKFLOW_DIR}/_shared/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
 3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
 4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.

--- a/workflows/sdd/REGISTRY.opencode.md
+++ b/workflows/sdd/REGISTRY.opencode.md
@@ -78,9 +78,8 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 ### How to Start (MANDATORY)
 
 When SDD is triggered:
-1. The `sdd-orchestrator` agent is the active primary agent — its full playbook is loaded from `opencode.json`. You ARE the orchestrator; do not try to re-invoke yourself.
-2. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
-3. Follow the Orchestrator instructions to delegate to phase sub-agents via the `Task` tool, using `subagent_type: '{WORKFLOW_SUBAGENT_<PHASE>}'` (the phase placeholders resolve to the agent names declared in `opencode.json`).
+1. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
+2. Follow the Orchestrator instructions to delegate to phase sub-agents via the `Task` tool, using `subagent_type: '{WORKFLOW_SUBAGENT_<PHASE>}'` (the phase placeholders resolve to the agent names declared in `opencode.json`).
 
 ### Delegation Rules
 
@@ -91,13 +90,12 @@ When SDD is triggered:
 
 ### Compaction Recovery (MANDATORY)
 
-After compaction, the OpenCode plugin emits a recovery context block if any active workflow marker exists. When you receive that recovery context:
+After compaction, the OpenCode plugin emits a recovery context block if any active workflow marker exists. Recovery reference: `{WORKFLOW_DIR}/_shared/recovery.md`. When you receive that recovery context:
 
-1. You are still the `sdd-orchestrator` agent — the full playbook is already in your prompt, including the recovery reference at `{WORKFLOW_DIR}/_shared/recovery.md`.
-2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
-3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
-4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.
-5. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
+1. Read `.sdd/{change}/state.yaml` for current phase and resume point.
+2. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
+3. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.
+4. Resume as delegate-only orchestrator via sub-agents, NEVER execute phase work inline.
 
 If no `active-workflow` marker is found, do nothing.
 

--- a/workflows/sdd/_shared/advisor-templates.md
+++ b/workflows/sdd/_shared/advisor-templates.md
@@ -15,7 +15,7 @@ Launch all requested advisors in parallel (run_in_background: true).
 
 Task(
   description: 'advisor consultation ({advisor-skill}) for {change-name}',
-  subagent_type: 'general-purpose',    // hardcoded — advisors are always general-purpose Task() calls
+  subagent_type: '{WORKFLOW_SUBAGENT_ADVISOR}',
   model: '{WORKFLOW_MODEL_ADVISOR}',
   run_in_background: true,
   prompt: 'You are a specialist advisor sub-agent. Load your skill:
@@ -81,7 +81,7 @@ Task(
 
 Task(
   description: 'advisor consultation ({advisor-skill}) for {change-name}',
-  subagent_type: 'general-purpose',
+  subagent_type: '{WORKFLOW_SUBAGENT_ADVISOR}',
   model: '{WORKFLOW_MODEL_ADVISOR}',
   run_in_background: false,   // OpenCode/Codex: foreground only
   prompt: '...same prompt body as parallel template above...'

--- a/workflows/sdd/_shared/advisor-templates.opencode.md
+++ b/workflows/sdd/_shared/advisor-templates.opencode.md
@@ -1,7 +1,4 @@
-# SDD Advisor Templates (OpenCode)
-
-<!-- SYNC WITH: advisor-templates.md (generic), advisor-templates.claude.md, advisor-templates.copilot.md -->
-<!-- OpenCode-only file. Installed name strips the .opencode.md suffix to advisor-templates.md. -->
+# SDD Advisor Templates
 
 These templates are used by the orchestrator when handling `guidance_requested` envelopes.
 See `launch-templates.md` for phase launch templates (explore, plan, implement, review).

--- a/workflows/sdd/_shared/advisor-templates.opencode.md
+++ b/workflows/sdd/_shared/advisor-templates.opencode.md
@@ -6,16 +6,10 @@
 These templates are used by the orchestrator when handling `guidance_requested` envelopes.
 See `launch-templates.md` for phase launch templates (explore, plan, implement, review).
 
-> **OpenCode constraint**: `run_in_background` is NOT supported. Advisors run sequentially as
-> foreground `Task()` calls — one at a time. There is no parallel template here.
-
 ## Sequential Advisor Consultation Template
 
-For each advisor in `requested_advisors[]`, launch a foreground `Task()` and wait for it to return
-before launching the next.
-
-> The advisor sub-agent's model is configured in `opencode.json` under
-> `agent.{WORKFLOW_SUBAGENT_ADVISOR}.model` — do not pass `model:` in the `Task()` call.
+For each advisor in `requested_advisors[]`, launch a `Task()` and wait for it to return before
+launching the next.
 
 ```
 Task(

--- a/workflows/sdd/_shared/advisor-templates.opencode.md
+++ b/workflows/sdd/_shared/advisor-templates.opencode.md
@@ -1,0 +1,116 @@
+# SDD Advisor Templates (OpenCode)
+
+<!-- SYNC WITH: advisor-templates.md (generic), advisor-templates.claude.md, advisor-templates.copilot.md -->
+<!-- OpenCode-only file. Installed name strips the .opencode.md suffix to advisor-templates.md. -->
+
+These templates are used by the orchestrator when handling `guidance_requested` envelopes.
+See `launch-templates.md` for phase launch templates (explore, plan, implement, review).
+
+> **OpenCode constraint**: `run_in_background` is NOT supported. Advisors run sequentially as
+> foreground `Task()` calls — one at a time. There is no parallel template here.
+
+## Sequential Advisor Consultation Template
+
+For each advisor in `requested_advisors[]`, launch a foreground `Task()` and wait for it to return
+before launching the next.
+
+> The advisor sub-agent's model is configured in `opencode.json` under
+> `agent.{WORKFLOW_SUBAGENT_ADVISOR}.model` — do not pass `model:` in the `Task()` call.
+
+```
+Task(
+  description: 'advisor consultation ({advisor-skill}) for {change-name}',
+  subagent_type: '{WORKFLOW_SUBAGENT_ADVISOR}',
+  prompt: 'You are a specialist advisor sub-agent for the {advisor-skill} role.
+
+  Load your skill instructions:
+    Read("{SKILLS_PATH}/{advisor-skill}/SKILL.md")
+
+  CONTEXT:
+  - Change: {change-name}
+  - Project: {project path}
+
+  GUIDANCE CONTEXT FROM PLANNER:
+  {guidance_context from envelope}
+
+  PLAN:
+  Read the full plan at: .sdd/{change-name}/plan.md
+  Focus your analysis on the sections relevant to your domain, but consider the full
+  architecture context — cross-section dependencies matter. The guidance_context above
+  tells you WHERE to focus; the plan gives you the FULL picture.
+
+  TASK:
+  Read the plan file first, then analyse from your specialist domain perspective.
+  Provide structured advice in this format:
+
+  ### Strengths
+  [What looks good in the current plan]
+
+  ### Issues Found
+  [Problems with severity: Critical / Major / Minor. Be specific — reference file paths and section names.]
+
+  ### Recommendations
+  [Specific actionable suggestions. Each recommendation should reference a plan task ID or section.]
+
+  PERSISTENCE:
+  Save your full advice output to engram (skip silently if engram is unavailable):
+    mem_save(
+      title: "sdd/{change-name}/guidance/{advisor-skill}",
+      type: "architecture",
+      project: "{project-name}",
+      content: "{your full structured advice output}"
+    )
+
+  RETURN FORMAT:
+  Return a short summary of your advice (3-5 bullet points) plus the engram observation ID (if saved).
+  Format:
+  ### Summary
+  - ...key points...
+  ### Engram ID
+  {observation_id or "unavailable"}
+
+  Do NOT produce an SDD Envelope.'
+)
+```
+
+After every advisor returns, collect its `Summary` and `Engram ID` (or inline summary text when engram
+is unavailable) before launching the next advisor.
+
+---
+
+## Plan Phase: Re-entry with Guidance Template
+
+When the orchestrator re-enters `sdd-plan` after collecting all advisor summaries, launch the planner
+again with the consolidated guidance block.
+
+```
+Task(
+  description: 'plan re-entry (guidance round {N}) for {change-name}',
+  subagent_type: '{WORKFLOW_SUBAGENT_PLANNER}',
+  prompt: 'Your instructions are in {SKILLS_PATH}/sdd-plan/SKILL.md — read it first, then follow those instructions.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact directory: .sdd/{change-name}/
+  - Previous artifacts: exploration.md, plan.md (EXISTING — revise, do not recreate)
+
+  GUIDANCE (Round {N}):
+  Advisor recommendations collected by orchestrator. For each entry below, fetch the full content via
+  mem_get_observation(id) when an engram ID is provided, or read the inline text directly otherwise.
+
+  {for each advisor:}
+  ### {advisor-skill} (engram ID: {observation_id or "inline"})
+  {if inline: paste advisor output directly}
+  {if ID: "Fetch via mem_get_observation({observation_id})"}
+
+  TASK:
+  Integrate the advisor recommendations into plan.md.
+  For each recommendation:
+  1. Assess whether it applies (some may not fit scope).
+  2. If it applies: update the relevant task, add/modify Detail Block, adjust Before/After, or add a new task.
+  3. Document integration in ## Advice Received section.
+  Skip the Deep Interview, Team Selection, and Guidance Request steps (already completed).
+  Re-run the Detail Quality Gate.'
+)
+```


### PR DESCRIPTION
## Summary

Two bugs surfaced in a recent OpenCode SDD session caused the orchestrator to stall mid-flow:

1. **Contradictory invocation syntax in the synthesised orchestrator prompt.** `REGISTRY.opencode.md` told the model to delegate via \`@<sub-agent>\` natural-language mentions, while \`ORCHESTRATOR.opencode.md\` (correctly) used the \`Task()\` tool. The OpenCode renderer concatenates both blocks into the \`sdd-orchestrator\` agent prompt in \`opencode.json\`, so the model received both instructions and could not decide which to follow.
2. **Hardcoded \`subagent_type: 'general-purpose'\` in advisor templates.** The catalog's \`workflow.yaml\` declares an \`sdd-advisor\` role and DevRune resolves \`{WORKFLOW_SUBAGENT_ADVISOR}\` to its agent name at install time, but the templates ignored the placeholder. For OpenCode that meant the orchestrator tried to launch an agent that does not exist in \`opencode.json\` — which is the agent runtime's source of truth.

## Changes

- **\`workflows/sdd/REGISTRY.opencode.md\`** — replace every \`@<sub-agent>\` / \`@sdd-{phase}\` reference with \`Task(subagent_type: '{WORKFLOW_SUBAGENT_<PHASE>}', ...)\`. Now consistent with \`ORCHESTRATOR.opencode.md\`.
- **\`workflows/sdd/_shared/advisor-templates.md\`** — swap \`'general-purpose'\` for \`'{WORKFLOW_SUBAGENT_ADVISOR}'\` in both the parallel and sequential templates. Generic file is still consumed by Claude/Factory; placeholder resolves correctly per renderer.
- **\`workflows/sdd/_shared/advisor-templates.opencode.md\`** (new) — OpenCode-only variant with just the Sequential template + Plan Re-entry template. Drops \`model:\` and \`run_in_background:\` from the \`Task()\` calls (OpenCode resolves the model from the agent definition in \`opencode.json\` and does not support \`run_in_background\`). The renderer renames it to \`advisor-templates.md\` for OpenCode installs and suppresses the generic — same pattern \`launch-templates\` already uses.

## Why a variant file (instead of expanding the generic with another section)

\`launch-templates\` already follows the per-agent variant convention (\`.claude.md\`, \`.copilot.md\`, \`.opencode.md\`) because invocation mechanics differ per agent. Advisor templates are the same situation — the OpenCode orchestrator should not have to read three plantillas and pick the right one each turn.

## Test plan

- [ ] \`devrune sync\` against a fresh OpenCode workspace pointing at this branch and confirm:
  - \`.opencode/sdd-orchestrator/_shared/advisor-templates.md\` contains \`subagent_type: 'sdd-advisor'\` (no \`general-purpose\`, no inline parallel template).
  - \`opencode.json\` orchestrator prompt has no \`@sdd-\` or \`@<sub-agent>\` references.
- [ ] Run an end-to-end SDD session in an OpenCode workspace; confirm the planner returning \`status: guidance_requested\` triggers an actual advisor consultation instead of stalling.
- [ ] Verify Claude / Factory installs are unchanged (generic \`advisor-templates.md\` still rendered for them; the new \`.opencode.md\` is suppressed by the variant filter).

## Related

Surfaced while debugging an OpenCode SDD session in \`davidarce/libraries\` where \`@sdd-orchestrator\` (gpt-5.5) deadlocked at the guidance loop.