### PR TITLE
refactor(workflows/sdd): use {SHARED_DIR} placeholder instead of {WORKFLOW_DIR}/_shared/

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -144,7 +144,7 @@ user choices and do NOT need re-validation. Recovery jumps straight to the next 
 ### Step 4 — Auto-launch explore
 
 Invoke `@sdd-explorer` directly. Use the per-phase invocation prompt from
-`{WORKFLOW_DIR}/_shared/launch-templates.md`. No user prompt — the user already chose to
+`{SHARED_DIR}/launch-templates.md`. No user prompt — the user already chose to
 start SDD by selecting this agent.
 
 ## Launching Sub-Agents
@@ -152,10 +152,10 @@ start SDD by selecting this agent.
 Phase work runs inside sub-agents you invoke by `@agent-name` natural-language mention.
 Each sub-agent is a native `.agent.md` file that loads its own SKILL.md.
 
-See `{WORKFLOW_DIR}/_shared/launch-templates.md` for the exact invocation prompts per phase
+See `{SHARED_DIR}/launch-templates.md` for the exact invocation prompts per phase
 (operational contract, envelope format, persistence, wave-scope discipline, quality gate
 directive, CRIT_FEEDBACK pattern). For advisor consultations during the plan guidance loop,
-see `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+see `{SHARED_DIR}/advisor-templates.md`.
 
 For each phase, invoke the corresponding agent:
 - **explore**: `@sdd-explorer` — "Explore the codebase for {change-name}. Write
@@ -180,9 +180,9 @@ returns `status: warning` or `status: failed` does manual validation belong here
 then only on the specific signals the envelope flagged.
 
 1. **Parse** the SDD Envelope from sub-agent output (format:
-   `{WORKFLOW_DIR}/_shared/envelope-contract.md`).
+   `{SHARED_DIR}/envelope-contract.md`).
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in
-   `{WORKFLOW_DIR}/_shared/persistence-contract.md`.
+   `{SHARED_DIR}/persistence-contract.md`.
 3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow`
    marker with NEXT directive.
 
@@ -210,12 +210,12 @@ then only on the specific signals the envelope flagged.
    b. Increment `guidance_round` in state.yaml.
    c. For each requested advisor: invoke `@{advisor-skill}` by name (e.g.
       `@architect-advisor`, `@api-first-advisor`) using the Copilot Advisor Invocation template
-      from `{WORKFLOW_DIR}/_shared/advisor-templates.md`. Each advisor is a `.agent.md` file
+      from `{SHARED_DIR}/advisor-templates.md`. Each advisor is a `.agent.md` file
       in `.github/agents/` and loads its SKILL.md directly.
    d. Run advisors sequentially (Copilot has no background execution). Collect each summary
       + engram ID before invoking the next advisor.
    e. Invoke `@sdd-planner` with the Plan Re-entry with Guidance format from
-      `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+      `{SHARED_DIR}/advisor-templates.md`.
    f. After `@sdd-planner` returns: loop back to step 1.
    - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
 6. **Crit detection** (plan phase only): After `plan` phase with `status: ok`, run `which crit`
@@ -274,7 +274,7 @@ phase.
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below).
      Re-launch `@sdd-planner` with the plan re-entry prompt (include the CRIT_FEEDBACK block
      and ask it to revise plan.md). The full re-entry prompt template is in
-     `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment
+     `{SHARED_DIR}/launch-templates.md`. After sub-agent returns envelope, increment
      `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next
      round — always foreground).
    - **No unresolved comments**: Plan approved. Set `crit_completed: true` in
@@ -348,7 +348,7 @@ mcp__engram__mem_save(topic_key: "sdd/{change}/active-workflow", ...,
 ## Compaction Recovery
 
 After compaction, if you receive a recovery context block referencing an active workflow
-marker, the recovery reference is `{WORKFLOW_DIR}/_shared/recovery.md`. When you receive that
+marker, the recovery reference is `{SHARED_DIR}/recovery.md`. When you receive that
 context:
 
 1. Read `.sdd/{change}/state.yaml` for current phase and resume point.
@@ -408,8 +408,8 @@ Accomplished, Next Steps, Relevant Files.
 
 ## References
 
-- Envelope format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`
-- Persistence rules: `{WORKFLOW_DIR}/_shared/persistence-contract.md`
-- Launch templates: `{WORKFLOW_DIR}/_shared/launch-templates.md`
-- Advisor templates: `{WORKFLOW_DIR}/_shared/advisor-templates.md`
-- Recovery flows: `{WORKFLOW_DIR}/_shared/recovery.md`
+- Envelope format: `{SHARED_DIR}/envelope-contract.md`
+- Persistence rules: `{SHARED_DIR}/persistence-contract.md`
+- Launch templates: `{SHARED_DIR}/launch-templates.md`
+- Advisor templates: `{SHARED_DIR}/advisor-templates.md`
+- Recovery flows: `{SHARED_DIR}/recovery.md`

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -32,7 +32,7 @@ If your next planned action is on the "do not" list, you have lost the role — 
 
 For every phase, use the `Task` tool to spawn a sub-agent. The sub-agent's prompt instructs IT to call `Skill("sdd-{phase}")` — the orchestrator never calls Skill itself.
 
-**Read `{WORKFLOW_DIR}/_shared/launch-templates.md` before your first launch** — it contains the exact copy-paste Task() calls for every phase (correct `subagent_type`, model, and prompt per phase).
+**Read `{SHARED_DIR}/launch-templates.md` before your first launch** — it contains the exact copy-paste Task() calls for every phase (correct `subagent_type`, model, and prompt per phase).
 
 ### First Sub-Agent of a New Workflow
 
@@ -87,8 +87,8 @@ The PRD is opt-in for thin contexts only — never force it, never offer it when
 
 **Trust the envelope.** A sub-agent that returns `status: ok` with a `Gates:` line listing project gate results (build / test / lint / format / type-check — whatever the project uses) has already run those gates and passed. The orchestrator MUST NOT re-run any verification command after an `ok` envelope — that's the implementer's contract, and re-running burns tokens, time, and Output Discipline. Only when an envelope returns `status: warning` or `status: failed` does manual validation belong here, and even then only on the specific signals the envelope flagged.
 
-1. **Parse** the SDD Envelope from sub-agent output (format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
-2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{WORKFLOW_DIR}/_shared/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
+1. **Parse** the SDD Envelope from sub-agent output (format: `{SHARED_DIR}/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope in the wave. Aggregate status: if all `ok` → wave is `ok`; if any `failed` → wave is `failed`; if any `warning` but none `failed` → wave is `warning`.
+2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `{SHARED_DIR}/persistence-contract.md`. For parallel waves: write the highest-severity status from all sub-agents in the wave.
 3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
 
    **NEXT Step Resolution** — set the NEXT directive based on what just completed:
@@ -113,12 +113,12 @@ The PRD is opt-in for thin contexts only — never force it, never offer it when
 5. **Guidance loop** (plan phase only): After `plan` phase returns `status: guidance_requested`:
    a. Extract `requested_advisors[]` and `guidance_context` from envelope.
    b. Increment `guidance_round` in state.yaml (for tracking only — no maximum).
-   c. Launch all advisors in parallel using the Advisor Consultation Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`. Use `run_in_background: true` for each.
+   c. Launch all advisors in parallel using the Advisor Consultation Template from `{SHARED_DIR}/advisor-templates.md`. Use `run_in_background: true` for each.
    d. Wait for all advisor background tasks to complete.
    e. Collect the summary and engram observation ID returned by each advisor.
       (Each advisor persists its own output to engram and returns the observation ID.)
       If an advisor reports engram unavailable: keep its returned inline summary text for step f.
-   f. Re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+   f. Re-launch sdd-plan using the Plan Re-entry with Guidance Template from `{SHARED_DIR}/advisor-templates.md`.
       - For each advisor: include its observation ID in the GUIDANCE block (planner fetches full content via mem_get_observation).
       - If engram unavailable for an advisor: include its inline summary text in the GUIDANCE block instead.
    g. After sdd-plan re-entry returns envelope: loop back to step 1 (Post-Phase Protocol from start).
@@ -155,7 +155,7 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
 4. **Read feedback**: Read `~/.crit/plans/{change}/.crit.json` using the Read tool. Note: plan mode stores `.crit.json` in `~/.crit/plans/{change}/`, NOT in the project root.
 5. **Parse**: Extract all comments where `resolved` is `false` or missing.
 6. **Branch**:
-   - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
+   - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{SHARED_DIR}/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
    - **No unresolved comments**: Plan approved. Set `crit_completed: true` in `.sdd/{change}/state.yaml`. Show "Plan approved via Crit review. Auto-launching implement phase." Proceed to Post-Phase step 7.
 
 **CRIT_FEEDBACK format** (injected into sdd-plan re-entry prompt):
@@ -185,7 +185,7 @@ A large plan exhausts a single sub-agent's context. The orchestrator drives wave
 2. Group batches into waves by dependency satisfaction
 3. For each wave:
    a. Identify batches: separate `Parallel=Yes` (no unmet deps) from sequential
-   b. Launch all `Parallel=Yes` batches as background Task() (use Parallel Batch Template from `{WORKFLOW_DIR}/_shared/launch-templates.md`)
+   b. Launch all `Parallel=Yes` batches as background Task() (use Parallel Batch Template from `{SHARED_DIR}/launch-templates.md`)
    c. Launch sequential batches as foreground Task() one at a time (use Sequential Batch Template)
    d. Wait for all background tasks to complete (Claude Code sends notification on completion)
    e. For each completed sub-agent (foreground and background): run Post-Phase Protocol
@@ -234,11 +234,11 @@ mem_save(topic_key: "sdd/{change}/active-workflow", ..., content: "COMPLETED|ABO
 
 ## Edge Cases and Recovery
 
-Compaction recovery, fail-fast error handling, abort/complete cleanup, and non-SDD context injection are in `{WORKFLOW_DIR}/_shared/recovery.md`.
+Compaction recovery, fail-fast error handling, abort/complete cleanup, and non-SDD context injection are in `{SHARED_DIR}/recovery.md`.
 
 ## References
 
-- Envelope format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`
-- Persistence rules: `{WORKFLOW_DIR}/_shared/persistence-contract.md`
-- Launch templates: `{WORKFLOW_DIR}/_shared/launch-templates.md`
-- Recovery flows: `{WORKFLOW_DIR}/_shared/recovery.md`
+- Envelope format: `{SHARED_DIR}/envelope-contract.md`
+- Persistence rules: `{SHARED_DIR}/persistence-contract.md`
+- Launch templates: `{SHARED_DIR}/launch-templates.md`
+- Recovery flows: `{SHARED_DIR}/recovery.md`

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -142,7 +142,7 @@ user choices and do NOT need re-validation. Recovery jumps straight to the next 
 
 ### Step 4 — Auto-launch explore
 
-Use the Generic Sub-Agent Template from `{WORKFLOW_DIR}/_shared/launch-templates.md`. No user
+Use the Generic Sub-Agent Template from `{SHARED_DIR}/launch-templates.md`. No user
 prompt — the user already chose to start SDD by selecting this agent.
 
 ## Launching Sub-Agents
@@ -151,10 +151,10 @@ Phase work runs inside sub-agents you launch via the `Task` tool. You pass dynam
 (project path, change name, artifact directory, previous artifacts); the sub-agent reads its
 own SKILL.md from disk and follows it.
 
-**Read `{WORKFLOW_DIR}/_shared/launch-templates.md` before your first launch** — it contains
+**Read `{SHARED_DIR}/launch-templates.md` before your first launch** — it contains
 the exact copy-paste `Task()` calls for every phase (correct `subagent_type`, prompt skeleton).
 For advisor consultations during the plan guidance loop, see
-`{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+`{SHARED_DIR}/advisor-templates.md`.
 
 After every sub-agent returns, run the Post-Phase Protocol below. Sub-agents return envelopes;
 you decide what runs next. Auto-transitions: `explore(ok) → plan`, `implement(ok) → review`.
@@ -169,9 +169,9 @@ returns `status: warning` or `status: failed` does manual validation belong here
 then only on the specific signals the envelope flagged.
 
 1. **Parse** the SDD Envelope from sub-agent output (format:
-   `{WORKFLOW_DIR}/_shared/envelope-contract.md`).
+   `{SHARED_DIR}/envelope-contract.md`).
 2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in
-   `{WORKFLOW_DIR}/_shared/persistence-contract.md`.
+   `{SHARED_DIR}/persistence-contract.md`.
 3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow`
    marker with NEXT directive.
 
@@ -199,10 +199,10 @@ then only on the specific signals the envelope flagged.
    b. Increment `guidance_round` in state.yaml.
    c. **Launch advisors sequentially** (OpenCode does not support `run_in_background`) using
       the Sequential Advisor Consultation Template from
-      `{WORKFLOW_DIR}/_shared/advisor-templates.md`. Run one advisor at a time; collect each
+      `{SHARED_DIR}/advisor-templates.md`. Run one advisor at a time; collect each
       summary + engram ID before launching the next.
    d. After all advisors complete: re-launch sdd-plan using the Plan Re-entry with Guidance
-      Template from `{WORKFLOW_DIR}/_shared/advisor-templates.md`.
+      Template from `{SHARED_DIR}/advisor-templates.md`.
    e. After sdd-plan re-entry returns envelope: loop back to step 1 (Post-Phase Protocol from
       start).
    - After non-plan phases or after `status: ok/warning/blocked/failed`: skip this step.
@@ -262,7 +262,7 @@ phase.
 5. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below).
      Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from
-     `{WORKFLOW_DIR}/_shared/launch-templates.md`. After sub-agent returns envelope, increment
+     `{SHARED_DIR}/launch-templates.md`. After sub-agent returns envelope, increment
      `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round
      — always foreground).
    - **No unresolved comments**: Plan approved. Set `crit_completed: true` in
@@ -298,7 +298,7 @@ A large plan exhausts a single sub-agent's context. Drive waves:
 3. For each wave:
    a. Identify all batches in the wave (ignore `Parallel=Yes` — all run sequentially).
    b. Launch each batch as foreground `Task()` one at a time (use Sequential Batch Template
-      from `{WORKFLOW_DIR}/_shared/launch-templates.md`).
+      from `{SHARED_DIR}/launch-templates.md`).
    c. After each batch: run Post-Phase Protocol.
    d. Verify `[X]` markers in plan.md for the batch.
    e. All `status: ok` → proceed to next batch / wave.
@@ -337,7 +337,7 @@ mem_save(topic_key: "sdd/{change}/active-workflow", ...,
 ## Compaction Recovery
 
 After compaction, the OpenCode plugin emits a recovery context block if any active workflow
-marker exists. Recovery reference: `{WORKFLOW_DIR}/_shared/recovery.md`. When you receive that
+marker exists. Recovery reference: `{SHARED_DIR}/recovery.md`. When you receive that
 recovery context:
 
 1. Read `.sdd/{change}/state.yaml` for current phase and resume point.
@@ -397,8 +397,8 @@ Next Steps, Relevant Files.
 
 ## References
 
-- Envelope format: `{WORKFLOW_DIR}/_shared/envelope-contract.md`
-- Persistence rules: `{WORKFLOW_DIR}/_shared/persistence-contract.md`
-- Launch templates: `{WORKFLOW_DIR}/_shared/launch-templates.md`
-- Advisor templates: `{WORKFLOW_DIR}/_shared/advisor-templates.md`
-- Recovery flows: `{WORKFLOW_DIR}/_shared/recovery.md`
+- Envelope format: `{SHARED_DIR}/envelope-contract.md`
+- Persistence rules: `{SHARED_DIR}/persistence-contract.md`
+- Launch templates: `{SHARED_DIR}/launch-templates.md`
+- Advisor templates: `{SHARED_DIR}/advisor-templates.md`
+- Recovery flows: `{SHARED_DIR}/recovery.md`

--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -95,7 +95,7 @@ When SDD is triggered:
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
-1. Re-load `Skill("sdd-orchestrator")` and read its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
+1. Re-load `Skill("sdd-orchestrator")` and read its recovery reference `{SHARED_DIR}/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
 3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
 4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -79,7 +79,7 @@ When a user describes work that involves code changes, you MUST evaluate BEFORE 
 
 When SDD is triggered:
 1. Load `Skill("sdd-orchestrator")` — if unavailable, read `{WORKFLOW_DIR}/ORCHESTRATOR.md` directly
-2. Read `{WORKFLOW_DIR}/_shared/launch-templates.md` — copy-paste templates for `Task()` calls
+2. Read `{SHARED_DIR}/launch-templates.md` — copy-paste templates for `Task()` calls
 3. Create artifact directory at the orchestrator's invocation directory: `mkdir -p {project path}/.sdd/{change-name}` — substitute `{project path}` with the absolute path captured from `pwd` at orchestrator start, and use that absolute path for every artifact reference passed to sub-agents.
 4. Follow the Orchestrator instructions to launch sub-agents via `Task()` tool
 
@@ -88,7 +88,7 @@ When SDD is triggered:
 ### Delegation Rules
 
 1. The orchestrator NEVER reads/writes code and NEVER calls Skill() directly — sub-agents do that. ONLY: track state, show summaries, collect decisions, launch sub-agents via `Task()`.
-2. To launch a phase: use `Task()` with prompt that tells the sub-agent to call `Skill("sdd-{phase}")`. See `{WORKFLOW_DIR}/_shared/launch-templates.md` for exact templates.
+2. To launch a phase: use `Task()` with prompt that tells the sub-agent to call `Skill("sdd-{phase}")`. See `{SHARED_DIR}/launch-templates.md` for exact templates.
 3. After EVERY sub-agent, execute the Post-Phase Protocol from the orchestrator playbook — NEVER skip it.
 4. Skills return envelopes; the orchestrator decides next steps. Auto-transitions: explore(ok)→plan, implement(ok)→review.
 
@@ -96,7 +96,7 @@ When SDD is triggered:
 
 After compaction, if memory has `sdd/*/active-workflow` observations starting with "ACTIVE":
 
-1. Re-read `{WORKFLOW_DIR}/ORCHESTRATOR.md` and its recovery reference `{WORKFLOW_DIR}/_shared/recovery.md`.
+1. Re-read `{WORKFLOW_DIR}/ORCHESTRATOR.md` and its recovery reference `{SHARED_DIR}/recovery.md`.
 2. Read `.sdd/{change}/state.yaml` for current phase and resume point.
 3. Parse the NEXT directive from the active-workflow marker (format: `NEXT: {phase} -> {specific next step}`) to determine the exact resume point.
 4. If NEXT mentions crit detection, re-run `which crit` to verify availability before proceeding.

--- a/workflows/sdd/_shared/launch-templates.opencode.md
+++ b/workflows/sdd/_shared/launch-templates.opencode.md
@@ -107,4 +107,4 @@ mem_save(
 )
 ```
 
-This enables compaction recovery (see `{WORKFLOW_DIR}/_shared/recovery.md`).
+This enables compaction recovery (see `{SHARED_DIR}/recovery.md`).

--- a/workflows/sdd/_shared/recovery.md
+++ b/workflows/sdd/_shared/recovery.md
@@ -16,7 +16,7 @@ If your next planned action is on the "do not" list, you have lost the role — 
 
 1. **Primary -- Read `.sdd/{change}/state.yaml`** (always works, file-based):
    - Parse YAML to get `current_phase`, `phases` map, and `artifacts` list
-   - Schema defined in `{WORKFLOW_DIR}/_shared/persistence-contract.md`
+   - Schema defined in `{SHARED_DIR}/persistence-contract.md`
 
 2. **Fallback -- Engram** (only if state.yaml is missing AND engram is available):
    ```
@@ -25,7 +25,7 @@ If your next planned action is on the "do not" list, you have lost the role — 
    ```
    NEVER use `mem_search` previews directly -- they are truncated.
 
-3. **Resume**: Continue from the next pending phase. Delegate via sub-agents using launch templates in `{WORKFLOW_DIR}/_shared/launch-templates.md`. If no state is recoverable, inform the user: **Restart** / **Abort**.
+3. **Resume**: Continue from the next pending phase. Delegate via sub-agents using launch templates in `{SHARED_DIR}/launch-templates.md`. If no state is recoverable, inform the user: **Restart** / **Abort**.
 
 ## Fail-Fast Error Handling
 


### PR DESCRIPTION
## Summary

Templates now reference workflow-shared assets via a single \`{SHARED_DIR}\` placeholder. The DevRune renderer resolves it to the agent-appropriate path:

| Agent | \`{SHARED_DIR}\` resolves to | Why |
|---|---|---|
| Claude / Factory / Codex | \`{WORKFLOW_DIR}/_shared/\` (= \`.{agent}/skills/sdd-orchestrator/_shared/\`) | Orchestrator IS a real skill on disk; \`_shared/\` legitimately lives inside it. **No path change.** |
| OpenCode | \`.opencode/<workflow-name>/_shared/\` | Orchestrator is a primary agent in \`opencode.json\` — the legacy \`.opencode/sdd-orchestrator/\` directory was a fantasma container with no SKILL.md. |
| Copilot | \`.github/<workflow-name>/_shared/\` | Orchestrator is a flat \`.agent.md\` — same fantasma problem as OpenCode. |

This decouples templates from per-agent path quirks: catalog maintainers write one reference (\`{SHARED_DIR}/launch-templates.md\`) instead of choosing between fantasma vs. real paths per agent.

## Changes

Mechanical replacement \`{WORKFLOW_DIR}/_shared/\` → \`{SHARED_DIR}/\` across:
- \`ORCHESTRATOR.md\` / \`ORCHESTRATOR.{claude,copilot,opencode}.md\`
- \`REGISTRY.md\` / \`REGISTRY.claude.md\`
- \`_shared/launch-templates.opencode.md\`
- \`_shared/recovery.md\`

\`{WORKFLOW_DIR}\` placeholder is preserved (still resolves to the workflow's \`workingDir\` — e.g. \`.{agent}/skills/sdd-orchestrator/\` for Claude/Factory/Codex). Future templates can use it if they need to reference the orchestrator's own dir for some other purpose.

## Pairing PR

DevRune renderer change: https://github.com/davidarce/DevRune/pull/new/refactor/sdd-shared-dir-placeholder

The DevRune PR introduces \`{SHARED_DIR}\` resolution and changes the install destination of \`_shared/\` for OpenCode/Copilot. Recommended order: merge DevRune first (so \`{SHARED_DIR}\` is recognised), then this catalog PR. Reverse order also works but produces broken paths in the materialised workspace until both land.

This PR depends on PR #60 (slim ORCHESTRATOR + drop REGISTRY for OpenCode/Copilot, already merged) — it builds on the post-#60 catalog state.

## Test plan

- [ ] Merge DevRune PR + this PR.
- [ ] \`devrune sync\` against an OpenCode workspace, then verify:
  - \`.opencode/sdd/_shared/\` exists with launch-templates.md, advisor-templates.md, etc.
  - \`.opencode/sdd-orchestrator/\` does NOT exist.
  - \`opencode.json\` orchestrator prompt's references resolve to \`.opencode/sdd/_shared/...\`.
- [ ] Same for Copilot: \`.github/sdd/_shared/\` exists, no \`.github/skills/sdd-orchestrator/\` fantasma dir, \`.agent.md\` references resolve correctly.
- [ ] Claude install unchanged: \`.claude/skills/sdd-orchestrator/_shared/\` still exists, references inside ORCHESTRATOR.md still resolve.