### PR TITLE
fix(workflows/sdd): git pre-flight guard + allow workflow-init branch creation

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -119,6 +119,12 @@ when it isn't.
 Run once, here — not at commit time. PRD content (when present) informs branch type more
 reliably than the raw user prompt.
 
+**Pre-flight — git availability**: Run `git rev-parse --is-inside-work-tree` first. If it
+returns a non-zero exit (the cwd is not inside a git repository — common for monorepo-style
+workspaces that aggregate multiple sub-repos at the root), **skip Step 3 entirely**. Tell
+the user once: "No git repository detected at the workflow root; branch setup skipped."
+Sub-agents that need to commit will run their own git commands inside the relevant sub-repo.
+
 - Read current branch: `git rev-parse --abbrev-ref HEAD`.
 - Read base reference: `git rev-parse --abbrev-ref origin/HEAD` (fallback `main` / `master`).
 - Decide if the current branch is **fit** for this change:
@@ -136,6 +142,10 @@ reliably than the raw user prompt.
   - When unclear, ask the user once: **feat** / **fix** / **refactor** / **chore** /
     **Stay on current branch**.
   - Run `git checkout -b {type}/{change-name}` from the base branch.
+
+> Branch creation here is part of workflow initialization, not a commit-mutating action.
+> The "no `git commit` / `push`" rule still holds — those belong to the `git-commit` and
+> `git-pull-request` skills invoked at the end of the workflow.
 
 When `.sdd/{change}/state.yaml` already exists (resume case): skip Steps 1–3 entirely. The
 branch was chosen at the original workflow start; mid-workflow branch changes are deliberate

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -2,7 +2,7 @@
 
 Outside `.sdd/{change}/`, your only outputs are: sub-agent launches (`Task` / `Agent` / `@<sub-agent>` per your variant), `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
-You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create commits/PRs, invoke `Skill("sdd-{phase}")` directly.
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 
@@ -40,6 +40,9 @@ When `.sdd/{change}/state.yaml` does NOT yet exist (genuine new workflow, not a 
 
 1. **Workdir**: `mkdir -p .sdd/{change}/` (absolute path resolved from the orchestrator invocation directory).
 2. **Branch setup** (run once, here — not at commit time):
+
+   **Pre-flight — git availability**: Run `git rev-parse --is-inside-work-tree` first. If it returns a non-zero exit (the cwd is not inside a git repository — common for monorepo-style workspaces that aggregate multiple sub-repos at the root), **skip Step 2 entirely**. Tell the user once: "No git repository detected at the workflow root; branch setup skipped." Sub-agents that need to commit will run their own git commands inside the relevant sub-repo.
+
    - Read current branch: `git rev-parse --abbrev-ref HEAD`.
    - Read base reference: `git rev-parse --abbrev-ref origin/HEAD` (fallback `main` / `master`).
    - Decide if the current branch is **fit** for this change:
@@ -54,6 +57,8 @@ When `.sdd/{change}/state.yaml` does NOT yet exist (genuine new workflow, not a 
        - "chore", "deps", "release" → `chore`
      - When unclear, ask once via `AskUserQuestion`: **feat** / **fix** / **refactor** / **chore** / **Stay on current branch**.
      - Run `git checkout -b {type}/{change-name}` from the base branch.
+
+   > Branch creation here is part of workflow initialization, not a commit-mutating action. The "no `git commit` / `push`" rule still holds — those belong to the `git-commit` and `git-pull-request` skills invoked at the end of the workflow.
 3. **Active-workflow marker** (engram, if available):
    ```
    mem_save(topic_key: "sdd/{change}/active-workflow", title: "sdd/{change}/active-workflow",

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -118,6 +118,12 @@ it isn't.
 Run once, here — not at commit time. PRD content (when present) informs branch type more
 reliably than the raw user prompt.
 
+**Pre-flight — git availability**: Run `git rev-parse --is-inside-work-tree` first. If it
+returns a non-zero exit (the cwd is not inside a git repository — common for monorepo-style
+workspaces that aggregate multiple sub-repos at the root), **skip Step 3 entirely**. Tell
+the user once: "No git repository detected at the workflow root; branch setup skipped."
+Sub-agents that need to commit will run their own git commands inside the relevant sub-repo.
+
 - Read current branch: `git rev-parse --abbrev-ref HEAD`.
 - Read base reference: `git rev-parse --abbrev-ref origin/HEAD` (fallback `main` / `master`).
 - Decide if the current branch is **fit** for this change:
@@ -135,6 +141,10 @@ reliably than the raw user prompt.
   - When unclear, ask once via `AskUserQuestion`: **feat** / **fix** / **refactor** / **chore**
     / **Stay on current branch**.
   - Run `git checkout -b {type}/{change-name}` from the base branch.
+
+> Branch creation here is part of workflow initialization, not a commit-mutating action.
+> The "no `git commit` / `push`" rule still holds — those belong to the `git-commit` and
+> `git-pull-request` skills invoked at the end of the workflow.
 
 When `.sdd/{change}/state.yaml` already exists (resume case): skip Steps 1–3 entirely. The
 branch was chosen at the original workflow start; mid-workflow branch changes are deliberate

--- a/workflows/sdd/REGISTRY.claude.md
+++ b/workflows/sdd/REGISTRY.claude.md
@@ -2,7 +2,7 @@
 
 When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Agent(subagent_type: 'sdd-{phase}', ...)`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
-You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create commits/PRs, invoke `Skill("sdd-{phase}")` directly.
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 

--- a/workflows/sdd/REGISTRY.md
+++ b/workflows/sdd/REGISTRY.md
@@ -2,7 +2,7 @@
 
 When acting as the SDD orchestrator (during any active SDD workflow, including post-compaction recovery), outside `.sdd/{change}/` your only outputs are: sub-agent launches via `Task()`, `AskUserQuestion`, `mkdir` for `.sdd/`, and `Bash(crit ...)` per the Crit Plan Review Protocol.
 
-You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create branches/commits/PRs, invoke `Skill("sdd-{phase}")` directly.
+You do **not**: `Edit`/`Write` source files, run builds/tests/lints, run `git commit`/`push`, create commits/PRs, invoke `Skill("sdd-{phase}")` directly.
 
 If your next planned action is on the "do not" list, you have lost the role — re-read this section and delegate.
 


### PR DESCRIPTION
## Summary

Two small fixes to the orchestrator's Step 3 \"Branch setup\":

1. **Pre-flight git guard** — when the workflow root is not inside a git repository (common for monorepo-style workspaces aggregating sub-repos), the orchestrator was running three failing \`git rev-parse\` commands silently and continuing without telling the user. Now it checks \`git rev-parse --is-inside-work-tree\` first and skips Step 3 with a single user-facing message: \"No git repository detected at the workflow root; branch setup skipped.\"

2. **Remove \"create branches\" from the \"you do not\" list** — the generic ORCHESTRATOR.md / REGISTRY.md / REGISTRY.claude.md previously said \"you do not: ... create branches/commits/PRs\" which contradicted the Branch setup step's explicit \`git checkout -b ...\`. gpt-5.5 caught the contradiction in a recent OpenCode test (\"the orchestrator restrictions say not to create branches, which is confusing\").

A blockquote next to the Branch setup step now spells out the distinction: workflow-init branch creation is allowed, but \`git commit\` / \`push\` still belong to the dedicated skills at the end of the workflow.

## Files changed

- \`ORCHESTRATOR.md\` — git guard added to Step 2 (Branch setup); \"branches\" removed from \"you do not\" list.
- \`ORCHESTRATOR.opencode.md\` — git guard added to Step 3 (Branch setup) + clarifying blockquote.
- \`ORCHESTRATOR.copilot.md\` — same as opencode.
- \`REGISTRY.md\` / \`REGISTRY.claude.md\` — \"branches\" removed from \"you do not\" list (Claude/Factory orchestrators see this line via the ambient catalog).

## Compatibility

Pure markdown edits in the catalog. No DevRune renderer changes needed. Safe to merge independently of any open DevRune PRs.

## Test plan

- [ ] After merge + \`devrune sync\`, run an SDD session in OpenCode from a non-git workspace (e.g. \`libraries/\`). Verify the orchestrator prints the \"No git repository detected\" message once and proceeds to Step 4 instead of running silent failing git commands.
- [ ] Run an SDD session inside a real git repo (e.g. \`DevRune/\`). Verify the pre-flight check passes and the existing branch setup logic runs unchanged.
- [ ] Same in Claude / Factory installs to confirm the \"branches\" word removal didn't break anything.