### PR TITLE
fix(workflows/sdd): smarter engram guard — recover from "ambiguous project"

### DIFF
--- a/.engram/config.json
+++ b/.engram/config.json
@@ -1,0 +1,3 @@
+{
+  "project_name": "devrune-starter-catalog"
+}

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -376,17 +376,35 @@ Engram tools (`mcp__engram__mem_save`, `mcp__engram__mem_search`, `mcp__engram__
 etc.) depend on an MCP server that may not be installed or configured. All engram operations
 MUST follow the availability guard pattern.
 
-**Detection**: At the start of a session or workflow, attempt a lightweight engram call (e.g.,
-`mcp__engram__mem_context`). If it succeeds, engram is available. If it fails or the tool is
-not recognized, engram is unavailable.
+**Detection** (run once per session, cache the result):
+
+1. Attempt `mcp__engram__mem_context()` with no arguments.
+2. **If it succeeds** → engram is available; cache `engram_available = true` and proceed.
+3. **If it fails**, classify the error:
+   - **Tool not recognised / MCP server missing** (errors mentioning "no such tool",
+     "unknown tool", "MCP server not running") → engram is genuinely unavailable; cache
+     `engram_available = false`.
+   - **Ambiguous project** (error mentions "ambiguous project", "multiple git repos found",
+     or a similar disambiguation message) → engram IS available, the cwd just contains
+     multiple sub-repos and engram needs an explicit `project`. Recover:
+       a. Call `mcp__engram__mem_current_project()` to ask engram for its best project guess.
+       b. If it returns a project name → cache `engram_project = <name>` and
+          `engram_available = true`. Pass `project: engram_project` on every subsequent
+          engram call.
+       c. If it also fails → cache `engram_available = false`.
+       d. Tell the user once: "Engram resolved to project `<name>` for this workflow. Set a
+          `.engram/config.json` at the workflow root to make this explicit."
+   - **Any other error** → cache `engram_available = false`.
 
 **Guard rules**:
 - **If available**: Use engram normally — save, search, recover as documented above.
+  Always pass `project: engram_project` when the disambiguation step set it.
 - **If unavailable**: Skip ALL engram operations silently. Do not emit errors, warnings, or
   user-facing messages about engram absence.
 - **Never block workflow**: No task, phase, or operation should fail because engram is not
   available. Engram is always complementary, never required.
-- **Do not retry**: If an engram call fails, skip it and continue. Do not retry or enter a loop.
+- **No retry loops**: At most one disambiguation retry via `mcp__engram__mem_current_project()`.
+  If that fails, treat engram as unavailable and continue.
 
 ## Session close protocol (mandatory)
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -365,17 +365,35 @@ Engram tools (`mem_save`, `mem_search`, `mem_context`, etc.) depend on an MCP se
 not be installed or configured. All engram operations MUST follow the availability guard
 pattern.
 
-**Detection**: At the start of a session or workflow, attempt a lightweight engram call (e.g.,
-`mem_context`). If it succeeds, engram is available. If it fails or the tool is not
-recognized, engram is unavailable.
+**Detection** (run once per session, cache the result):
+
+1. Attempt `mem_context()` with no arguments.
+2. **If it succeeds** → engram is available; cache `engram_available = true` and proceed.
+3. **If it fails**, classify the error:
+   - **Tool not recognised / MCP server missing** (errors mentioning "no such tool",
+     "unknown tool", "MCP server not running") → engram is genuinely unavailable; cache
+     `engram_available = false`.
+   - **Ambiguous project** (error mentions "ambiguous project", "multiple git repos found",
+     or a similar disambiguation message) → engram IS available, the cwd just contains
+     multiple sub-repos and engram needs an explicit `project`. Recover:
+       a. Call `mem_current_project()` to ask engram for its best project guess.
+       b. If it returns a project name → cache `engram_project = <name>` and
+          `engram_available = true`. Pass `project: engram_project` on every subsequent
+          engram call.
+       c. If it also fails → cache `engram_available = false`.
+       d. Tell the user once: "Engram resolved to project `<name>` for this workflow. Set a
+          `.engram/config.json` at the workflow root to make this explicit."
+   - **Any other error** → cache `engram_available = false`.
 
 **Guard rules**:
 - **If available**: Use engram normally — save, search, recover as documented above.
+  Always pass `project: engram_project` when the disambiguation step set it.
 - **If unavailable**: Skip ALL engram operations silently. Do not emit errors, warnings, or
   user-facing messages about engram absence.
 - **Never block workflow**: No task, phase, or operation should fail because engram is not
   available. Engram is always complementary, never required.
-- **Do not retry**: If an engram call fails, skip it and continue. Do not retry or enter a loop.
+- **No retry loops**: At most one disambiguation retry via `mem_current_project()`. If that
+  fails, treat engram as unavailable and continue.
 
 ## Session close protocol (mandatory)
 

--- a/workflows/sdd/_shared/persistence-contract.md
+++ b/workflows/sdd/_shared/persistence-contract.md
@@ -152,20 +152,40 @@ mem_save(
 
 ## Engram Availability Guard Pattern
 
-All engram operations MUST use the try/skip pattern. Engram may not be installed or configured.
+All engram operations MUST use the try/skip pattern. Engram may not be installed or
+configured, and even when it is, the cwd may contain multiple sub-repos that confuse
+project resolution.
 
 ### Detection (once per session)
 
-At session start, the orchestrator attempts:
+At session start, the orchestrator attempts `mem_context()` and classifies the outcome:
 
 ```
-try:  mem_context(project: "{project}")
-      -> engram_available = true
-catch (tool not found / error):
-      -> engram_available = false
+try:  mem_context()
+      -> engram_available = true; engram_project = (whatever engram resolved)
+
+catch error:
+  if error is "tool not found" / "unknown tool" / "MCP server not running":
+      -> engram_available = false   # genuinely missing
+
+  elif error mentions "ambiguous project" or "multiple git repos":
+      -> engram IS installed; cwd just needs disambiguation.
+         Recover by calling mem_current_project():
+           if it returns a project name:
+             -> engram_available = true; engram_project = <name>
+                Pass project: engram_project on every later engram call.
+                Tell user once: "Engram resolved to project <name>; set
+                .engram/config.json at the workflow root to make this explicit."
+           else:
+             -> engram_available = false
+
+  else:
+      -> engram_available = false   # unknown error, fail-safe
 ```
 
-Cache the result. Do NOT re-check per operation.
+Cache `engram_available` and `engram_project`. Do NOT re-check per operation.
+
+At most ONE disambiguation retry via `mem_current_project()`. No retry loops.
 
 ### Guard Pattern for Sub-Agents
 


### PR DESCRIPTION
## Summary

The current engram availability guard collapses two distinct failure modes into the same \"engram unavailable\" outcome:

1. **Engram MCP server not installed / not running** — genuine unavailability, correct to skip.
2. **Engram IS installed but the cwd contains multiple git sub-repos** — engram cannot auto-pick a default project; recoverable with one extra call.

Case (2) is the common monorepo-style workspace scenario. A recent OpenCode SDD test in \`libraries/\` (which is not a git repo and contains DevRune, lib-purchaseai, devrune-starter-catalog, ...) hit it head-on: \`mem_context()\` failed with \"ambiguous project: multiple git repos found in cwd\", the orchestrator declared engram unavailable, never wrote the active-workflow marker, and the entire recovery path was lost for that workflow.

## Changes

Updated the guard pattern in three files:
- \`ORCHESTRATOR.opencode.md\` (Engram Availability Guard section)
- \`ORCHESTRATOR.copilot.md\` (same section, mcp__ namespacing)
- \`_shared/persistence-contract.md\` (Engram Availability Guard Pattern)

New detection flow:

\`\`\`
try mem_context()
  succeeds → engram_available=true; cache engram_project
  fails:
    \"tool not found\" / \"MCP server not running\" → unavailable (skip silently)
    \"ambiguous project\" / \"multiple git repos\" → recover via mem_current_project()
        if it returns a name → engram_available=true, engram_project=<name>
                              tell user once: suggest .engram/config.json
        else → unavailable
    other error → fail-safe to unavailable
\`\`\`

At most ONE disambiguation retry. No retry loops.

Also includes \`.engram/config.json\` at the catalog repo root (\`{\"project_name\": \"devrune-starter-catalog\"}\`) so anyone cloning the catalog as a standalone workspace gets engram pre-configured — same pattern recommended to users via the new guard's hint message.

## Why this matters

The pattern \"thin failure classification → assume worst case\" was eating engram functionality for any user with a multi-repo workspace at the orchestrator's invocation directory. Most monorepo-style workflows hit this. The fix preserves the existing \"silent skip when truly unavailable\" semantics while recovering the much more common disambiguation case.

## Compatibility

Pure markdown edits in the catalog. No DevRune renderer changes. Safe to merge independently.

## Test plan

- [ ] Merge + \`devrune sync\` against an OpenCode workspace.
- [ ] Run an SDD session in \`libraries/\` (multi-repo, not a git repo). Verify the orchestrator:
  - Calls \`mem_context()\` first; if it returns ambiguous, calls \`mem_current_project()\`.
  - Caches the resolved project and uses it for subsequent engram calls.
  - Successfully writes the active-workflow marker.
  - Tells the user once about the resolved project and suggests \`.engram/config.json\`.
- [ ] Run an SDD session in a single-repo workspace (e.g. \`DevRune/\`). Verify \`mem_context()\` succeeds on first try with no recovery path triggered.
- [ ] Run an SDD session in a workspace where engram is genuinely not installed. Verify the orchestrator silently skips engram operations as before.