### PR TITLE
fix(workflows/sdd): orchestrator audit — Crit path, tool names, narration tightening, envelope contract

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -166,10 +166,10 @@ Triggered by Post-Phase step 6 when `which crit` succeeds after a plan phase.
 1. **Pre-flight**: scan for stale daemons (`pgrep -f "crit plan.*{change}"`); if a leftover from an earlier round is still alive, `pkill -f "crit plan.*{change}"`. Avoids the EOF / "could not reach crit daemon" failure where a half-dead daemon eats the new request.
 2. **Launch**: Run `crit plan --name {change} .sdd/{change}/plan.md` in background (Bash, `run_in_background: true`). Tell user: "Crit is open in your browser. Leave inline comments, then click Finish Review."
 3. **Wait**: Do NOT proceed until the background task completes.
-   - **If the call fails with a daemon error** (`could not reach crit daemon`, `EOF`, connection refused) AND no `~/.crit/plans/{change}/.crit.json` yet: do **one** auto-retry silently — `pkill -f "crit plan.*{change}"` and re-launch step 2. Do NOT narrate the retry to the user. If the retry also fails, ask: **Retry Crit review** / **Skip Crit, review plan manually** / **Approve plan as-is**. Do NOT loop the auto-retry beyond one attempt.
+   - **If the call fails with a daemon error** (`could not reach crit daemon`, `EOF`, connection refused) AND no `~/.crit/plans/{change}/.crit/review.json` yet: do **one** auto-retry silently — `pkill -f "crit plan.*{change}"` and re-launch step 2. Do NOT narrate the retry to the user. If the retry also fails, ask: **Retry Crit review** / **Skip Crit, review plan manually** / **Approve plan as-is**. Do NOT loop the auto-retry beyond one attempt.
    - **If the call times out** (user took too long): Do NOT treat as approval. Ask the user with the same three options.
-   - **If `.crit.json` exists despite a Bash error**: the daemon wrote feedback before dying — proceed to step 4 with the file as truth.
-4. **Read feedback**: Read `~/.crit/plans/{change}/.crit.json`. Note: plan mode stores `.crit.json` in `~/.crit/plans/{change}/`, NOT in the project root.
+   - **If `.crit/review.json` exists despite a Bash error**: the daemon wrote feedback before dying — proceed to step 4 with the file as truth.
+4. **Read feedback**: Read `~/.crit/plans/{change}/.crit/review.json`. Note: plan mode stores `.crit/review.json` in `~/.crit/plans/{change}/`, NOT in the project root.
 5. **Parse**: Extract comments where `resolved` is `false` or missing.
 6. **Branch**:
    - **Unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-planner` via `Agent(subagent_type: 'sdd-planner', ...)` with the CRIT_FEEDBACK block in the prompt. After envelope returns, increment `plan_review_round` and loop back to step 1.
@@ -236,7 +236,7 @@ mem_save(topic_key: "sdd/{change}/active-workflow", ..., content: "COMPLETED|ABO
 2. **Stale [X] markers**: Always verify plan.md markers after each implement wave.
 3. **Engram previews are truncated**: Never use `mem_search` results directly. Always follow with `mem_get_observation`.
 4. **Post-Phase skipping**: System-level "be concise" instructions do NOT override the Post-Phase Protocol.
-5. **Crit timeout ≠ approval**: If `crit plan` is killed by timeout or fails, absence of `.crit.json` means the review was NEVER completed. ALWAYS ask before proceeding to implement.
+5. **Crit timeout ≠ approval**: If `crit plan` is killed by timeout or fails, absence of `.crit/review.json` means the review was NEVER completed. ALWAYS ask before proceeding to implement.
 
 ## Edge Cases and Recovery
 

--- a/workflows/sdd/ORCHESTRATOR.copilot.md
+++ b/workflows/sdd/ORCHESTRATOR.copilot.md
@@ -36,14 +36,34 @@ This applies to you, every sub-agent you invoke, and every skill loaded from the
 If your next sentence would just narrate what your tool call already shows, delete the sentence
 and call the tool.
 
-**Forbidden — pre-action narration** ("I am going to / Let me / About to / Now I'll..."):
+**Forbidden — pre-action narration** ("I am going to / Let me / About to / Now I'll..." +
+phase-transition narration like "Auto-launching X" / "Cambio a Y" / "Re-launch Z"):
 
-| ❌ Don't say | ✅ Do |
+| ❌ Don't say (and the call still runs) | ✅ Do |
 |---|---|
 | "I'll verify the state first" | run the verify command |
 | "Now checking if crit is available before updating state" | run `which crit`, then update state |
 | "Now launching wave 2" | launch wave 2 |
 | "Let me read the file first" | read the file |
+| "Auto-launching plan." | invoke `@sdd-planner` |
+| "Crit terminó con feedback. Leyendo comentarios." | read the file |
+| "Plan revisado. Re-lanzo Crit para Round 2." | re-launch crit |
+| "Plan aprobado vía Crit. Actualizo state y lanzo implement." | write state.yaml + invoke `@sdd-implementer` |
+| "Cambio a una rama nueva y lanzo el skill de PRD." | run the git command + invoke the skill |
+
+**The pattern to avoid**: "I am about to do X" or "X happened, now I do Y". The tool call shows
+both. The narration adds nothing the diff or the next tool call won't already convey.
+
+**Forbidden — bash echo as a "marker" before a question or another action**:
+
+The `vscode/askQuestions` tool and equivalent prompts ARE valid actions on their own. You do NOT
+need a `bash echo` (or any other no-op tool call) before them. If your next move is to ask the
+user, ask. If your next move is to read a file, read it.
+
+| ❌ Don't do this | ✅ Do this |
+|---|---|
+| `bash: echo "Question for user"` followed by the question | just ask the question |
+| `bash: echo "Asking interview questions"` | just ask |
 
 **Forbidden — paraphrasing tool calls**:
 
@@ -60,12 +80,16 @@ and call the tool.
 - "now running the gate", "launching the sub-agent"
 - The scope check enumeration — compute silently, act on the result
 
-**Allowed — only these four classes**:
+**Allowed — only these three classes**:
 
 1. **Questions** the user has to answer (PRD gate, post-phase decisions, blockers requiring input).
 2. **Envelope summaries** from sub-agents — verbatim or tightly condensed, after parsing.
-3. **Outcome statements** when a phase / wave / commit closes — one line, no narration of how.
-4. **Errors and blockers** the user needs to act on.
+3. **Errors and blockers** the user needs to act on.
+
+(Outcome statements like "Phase X done" are deliberately NOT in the allowed list. The
+sub-agent's envelope already conveys what closed; reprinting it adds noise. The only
+exception is when the next thing the user must do is decide — in which case you are
+asking a question, which is class 1.)
 
 **The test before every sentence**: would the user learn something new from this that the diff
 or tool call doesn't already show? If not, don't say it.
@@ -103,7 +127,7 @@ Catches poor context before burning tokens on exploration.
 
    If 2 or more boxes are checked, context is sufficient. If fewer than 2, context is THIN.
 2. **If context is sufficient**: skip to Step 3 (no user prompt).
-3. **If context is thin**: ask the user once:
+3. **If context is thin**: ask the user once (via `#tool:vscode/askQuestions`):
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
 4. **If "Draft PRD"**: invoke the skill `write-a-prd` with the change-name. The skill runs the
@@ -139,7 +163,7 @@ Sub-agents that need to commit will run their own git commands inside the releva
     - "refactor", "cleanup", "tidy", "rename", "extract" → `refactor`
     - "docs", "documentation" → `docs`
     - "chore", "deps", "release" → `chore`
-  - When unclear, ask the user once: **feat** / **fix** / **refactor** / **chore** /
+  - When unclear, ask the user once (via `#tool:vscode/askQuestions`): **feat** / **fix** / **refactor** / **chore** /
     **Stay on current branch**.
   - Run `git checkout -b {type}/{change-name}` from the base branch.
 
@@ -243,7 +267,7 @@ then only on the specific signals the envelope flagged.
      auto-launch implement (no ask — the human already approved the plan inline via Crit,
      asking again is redundant).
    - implement `status: ok` → auto-launch review (no ask).
-   - All other cases → ask the user: **Continue to {next}** / **Review artifacts** /
+   - All other cases → ask the user (via `#tool:vscode/askQuestions`): **Continue to {next}** / **Review artifacts** /
      **Abort**.
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with
@@ -269,16 +293,16 @@ phase.
    open in your browser. Leave inline comments on the plan, then click Finish Review." Do NOT
    proceed until the call returns — it blocks until the user clicks Finish Review.
    - **If the call fails with a daemon error** (`could not reach crit daemon`, `EOF`,
-     connection refused) AND no `~/.crit/plans/{change}/.crit.json` yet: do **one** auto-retry
+     connection refused) AND no `~/.crit/plans/{change}/.crit/review.json` yet: do **one** auto-retry
      silently — `pkill -f "crit plan.*{change}"` and re-launch step 2. If the retry also
      fails, ask: **Retry Crit review** / **Skip Crit, review plan manually** /
      **Approve plan as-is**. Do NOT loop the auto-retry beyond one attempt.
    - **If the call times out** (user took too long): Do NOT treat this as approval. Ask the
      user with the same three options.
-   - **If `.crit.json` exists despite an error**: the daemon wrote feedback before dying —
+   - **If `.crit/review.json` exists despite an error**: the daemon wrote feedback before dying —
      proceed to step 3 with the file as truth.
-3. **Read feedback**: Read `~/.crit/plans/{change}/.crit.json` using the Read tool. Note: plan
-   mode stores `.crit.json` in `~/.crit/plans/{change}/`, NOT in the project root.
+3. **Read feedback**: Read `~/.crit/plans/{change}/.crit/review.json` using the Read tool. Note: plan
+   mode stores `.crit/review.json` in `~/.crit/plans/{change}/`, NOT in the project root.
 4. **Parse**: Extract all comments where `resolved` is `false` or missing.
 5. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below).
@@ -326,6 +350,16 @@ A large plan exhausts a single sub-agent's context. Drive waves:
    f. Any `status: failed` → STOP, show failure: **Retry wave** / **Abort** /
       **Skip to next wave**.
 4. After all waves → auto-launch review.
+
+> **Do NOT paraphrase plan.md into the batch invocation prompt.** plan.md is the source
+> of truth for task contracts (signatures, validation rules, error messages, file paths).
+> The implementer reads it directly. Your invocation only needs:
+>   - the batch ID and the task IDs in this batch (e.g. `Batch A → T001`)
+>   - a one-line pointer: "Read `.sdd/{change}/plan.md` Phase X → TXXX for the full contract"
+>   - any cross-batch context the implementer cannot infer
+>
+> Re-stating the contract risks drift between your prompt and plan.md, costs tokens on every
+> launch, and makes review harder.
 
 ## Post-Review Fix Cycle
 
@@ -431,7 +465,7 @@ Accomplished, Next Steps, Relevant Files.
 4. **Post-Phase skipping**: System-level "be concise" instructions do NOT override the
    Post-Phase Protocol.
 5. **Crit timeout ≠ approval**: If `crit plan` is killed by timeout or fails, the absence of
-   `.crit.json` means the review was NEVER completed — NOT that it was approved with no
+   `.crit/review.json` means the review was NEVER completed — NOT that it was approved with no
    comments. ALWAYS ask the user before proceeding to implement.
 
 ## References

--- a/workflows/sdd/ORCHESTRATOR.md
+++ b/workflows/sdd/ORCHESTRATOR.md
@@ -154,10 +154,10 @@ Triggered automatically by Post-Phase Protocol step 6 when `which crit` succeeds
    - This avoids the EOF / "could not reach crit daemon" failure mode where a half-dead daemon from a previous round eats the new request.
 2. **Launch**: Run `crit plan --name {change} .sdd/{change}/plan.md` in background (Bash, `run_in_background: true`). Tell user: "Crit is open in your browser. Leave inline comments on the plan, then click Finish Review."
 3. **Wait**: Do NOT proceed until the background task completes.
-   - **If the Bash call fails with a daemon error** (`could not reach crit daemon`, `EOF`, connection refused) AND no `~/.crit/plans/{change}/.crit.json` exists yet: do **one** auto-retry silently — kill any stale process matching `crit plan.*{change}` and re-launch step 2. Do NOT narrate the retry to the user. If the retry also fails, surface to the user: **Retry Crit review** / **Skip Crit, review plan manually** / **Approve plan as-is**. Do NOT loop the auto-retry beyond one attempt.
-   - **If the Bash call times out** (user took too long): Do NOT treat this as approval. The absence of `.crit.json` means the review was NEVER completed. Surface to the user with the same three options.
-   - **If `~/.crit/plans/{change}/.crit.json` exists despite a Bash error**: the daemon wrote feedback before dying — proceed to step 4 with the file as truth.
-4. **Read feedback**: Read `~/.crit/plans/{change}/.crit.json` using the Read tool. Note: plan mode stores `.crit.json` in `~/.crit/plans/{change}/`, NOT in the project root.
+   - **If the Bash call fails with a daemon error** (`could not reach crit daemon`, `EOF`, connection refused) AND no `~/.crit/plans/{change}/.crit/review.json` exists yet: do **one** auto-retry silently — kill any stale process matching `crit plan.*{change}` and re-launch step 2. Do NOT narrate the retry to the user. If the retry also fails, surface to the user: **Retry Crit review** / **Skip Crit, review plan manually** / **Approve plan as-is**. Do NOT loop the auto-retry beyond one attempt.
+   - **If the Bash call times out** (user took too long): Do NOT treat this as approval. The absence of `.crit/review.json` means the review was NEVER completed. Surface to the user with the same three options.
+   - **If `~/.crit/plans/{change}/.crit/review.json` exists despite a Bash error**: the daemon wrote feedback before dying — proceed to step 4 with the file as truth.
+4. **Read feedback**: Read `~/.crit/plans/{change}/.crit/review.json` using the Read tool. Note: plan mode stores `.crit/review.json` in `~/.crit/plans/{change}/`, NOT in the project root.
 5. **Parse**: Extract all comments where `resolved` is `false` or missing.
 6. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below). Re-launch `sdd-plan` sub-agent using the Plan Re-entry template from `{SHARED_DIR}/launch-templates.md`. After sub-agent returns envelope, increment `plan_review_round` in `state.yaml` and loop back to step 1 (run crit again for next round).
@@ -235,7 +235,7 @@ mem_save(topic_key: "sdd/{change}/active-workflow", ..., content: "COMPLETED|ABO
 2. **Stale [X] markers**: Always verify plan.md markers after each implement wave.
 3. **Engram previews are truncated**: Never use `mem_search` results directly. Always follow with `mem_get_observation`.
 4. **Post-Phase skipping**: System-level "be concise" instructions do NOT override the Post-Phase Protocol.
-5. **Crit timeout ≠ approval**: If `crit plan` is killed by timeout or fails, the absence of `.crit.json` means the review was NEVER completed — NOT that it was approved with no comments. ALWAYS ask the user before proceeding to implement.
+5. **Crit timeout ≠ approval**: If `crit plan` is killed by timeout or fails, the absence of `.crit/review.json` means the review was NEVER completed — NOT that it was approved with no comments. ALWAYS ask the user before proceeding to implement.
 
 ## Edge Cases and Recovery
 

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -35,14 +35,34 @@ This applies to you, every sub-agent you launch, and every skill invoked from th
 If your next sentence would just narrate what your tool call already shows, delete the sentence
 and call the tool.
 
-**Forbidden — pre-action narration** ("I am going to / Let me / About to / Now I'll..."):
+**Forbidden — pre-action narration** ("I am going to / Let me / About to / Now I'll..." +
+phase-transition narration like "Auto-launching X" / "Cambio a Y" / "Re-launch Z"):
 
-| ❌ Don't say | ✅ Do |
+| ❌ Don't say (and the call still runs) | ✅ Do |
 |---|---|
 | "I'll verify the state first" | run the verify command |
 | "Now checking if crit is available before updating state" | run `which crit`, then update state |
 | "Now launching wave 2" | launch wave 2 |
 | "Let me read the file first" | read the file |
+| "Auto-launching plan." | launch the planner |
+| "Crit terminó con feedback. Leyendo comentarios." | read the file |
+| "Plan revisado. Re-lanzo Crit para Round 2." | re-launch crit |
+| "Plan aprobado vía Crit. Actualizo state y lanzo implement." | write state.yaml + launch implement |
+| "Cambio a una rama nueva y lanzo el skill de PRD." | run the git command + invoke the skill |
+
+**The pattern to avoid**: "I am about to do X" or "X happened, now I do Y". The tool call shows
+both. The narration adds nothing the diff or the next tool call won't already convey.
+
+**Forbidden — bash echo as a "marker" before a question or another action**:
+
+The `question` tool and `AskUserQuestion`-equivalent prompts ARE valid actions on their own.
+You do NOT need a `bash echo` (or any other no-op tool call) before them. If your next move
+is to ask the user, ask. If your next move is to read a file, read it.
+
+| ❌ Don't do this | ✅ Do this |
+|---|---|
+| `bash: echo "Question for user"` followed by the question | just ask the question |
+| `bash: echo "Asking interview questions"` | just ask |
 
 **Forbidden — paraphrasing tool calls**:
 
@@ -59,12 +79,16 @@ and call the tool.
 - "now running the gate", "launching the sub-agent"
 - The scope check enumeration — compute silently, act on the result
 
-**Allowed — only these four classes**:
+**Allowed — only these three classes**:
 
 1. **Questions** the user has to answer (PRD gate, post-phase decisions, blockers requiring input).
 2. **Envelope summaries** from sub-agents — verbatim or tightly condensed, after parsing.
-3. **Outcome statements** when a phase / wave / commit closes — one line, no narration of how.
-4. **Errors and blockers** the user needs to act on.
+3. **Errors and blockers** the user needs to act on.
+
+(Outcome statements like "Phase X done" are deliberately NOT in the allowed list. The
+sub-agent's envelope already conveys what closed; reprinting it adds noise. The only
+exception is when the next thing the user must do is decide — in which case you are
+asking a question, which is class 1.)
 
 **The test before every sentence**: would the user learn something new from this that the diff
 or tool call doesn't already show? If not, don't say it.
@@ -102,7 +126,7 @@ Catches poor context before burning tokens on exploration.
 
    If 2 or more boxes are checked, context is sufficient. If fewer than 2, context is THIN.
 2. **If context is sufficient**: skip to Step 3 (no user prompt).
-3. **If context is thin**: ask once via `AskUserQuestion`:
+3. **If context is thin**: ask once via `question`:
    - "Draft a PRD first to clarify scope" (recommended)
    - "Proceed anyway with what we have"
 4. **If "Draft PRD"**: invoke `Skill("write-a-prd")` with the change-name. The skill runs the
@@ -138,7 +162,7 @@ Sub-agents that need to commit will run their own git commands inside the releva
     - "refactor", "cleanup", "tidy", "rename", "extract" → `refactor`
     - "docs", "documentation" → `docs`
     - "chore", "deps", "release" → `chore`
-  - When unclear, ask once via `AskUserQuestion`: **feat** / **fix** / **refactor** / **chore**
+  - When unclear, ask once via `question`: **feat** / **fix** / **refactor** / **chore**
     / **Stay on current branch**.
   - Run `git checkout -b {type}/{change-name}` from the base branch.
 
@@ -231,7 +255,7 @@ then only on the specific signals the envelope flagged.
      auto-launch implement (no ask — the human already approved the plan inline via Crit,
      asking again is redundant).
    - implement `status: ok` → auto-launch review (no ask).
-   - All other cases → `AskUserQuestion`: **Continue to {next}** / **Review artifacts** /
+   - All other cases → `question`: **Continue to {next}** / **Review artifacts** /
      **Abort**.
 
    **Crit confirmation guard** (plan phase, when crit IS available): After plan phase with
@@ -258,16 +282,16 @@ phase.
    Finish Review." Do NOT proceed until the Bash call returns — it blocks until the user
    clicks Finish Review.
    - **If the Bash call fails with a daemon error** (`could not reach crit daemon`, `EOF`,
-     connection refused) AND no `~/.crit/plans/{change}/.crit.json` yet: do **one** auto-retry
+     connection refused) AND no `~/.crit/plans/{change}/.crit/review.json` yet: do **one** auto-retry
      silently — `pkill -f "crit plan.*{change}"` and re-launch step 2. If the retry also
      fails, ask: **Retry Crit review** / **Skip Crit, review plan manually** /
      **Approve plan as-is**. Do NOT loop the auto-retry beyond one attempt.
    - **If the Bash call times out** (user took too long): Do NOT treat this as approval. Ask
      the user with the same three options.
-   - **If `.crit.json` exists despite a Bash error**: the daemon wrote feedback before dying —
+   - **If `.crit/review.json` exists despite a Bash error**: the daemon wrote feedback before dying —
      proceed to step 3 with the file as truth.
-3. **Read feedback**: Read `~/.crit/plans/{change}/.crit.json` using the Read tool. Note: plan
-   mode stores `.crit.json` in `~/.crit/plans/{change}/`, NOT in the project root.
+3. **Read feedback**: Read `~/.crit/plans/{change}/.crit/review.json` using the Read tool. Note: plan
+   mode stores `.crit/review.json` in `~/.crit/plans/{change}/`, NOT in the project root.
 4. **Parse**: Extract all comments where `resolved` is `false` or missing.
 5. **Branch**:
    - **Has unresolved comments**: Format as CRIT_FEEDBACK markdown (see format below).
@@ -315,6 +339,19 @@ A large plan exhausts a single sub-agent's context. Drive waves:
    f. Any `status: failed` → STOP, show failure: **Retry wave** / **Abort** /
       **Skip to next wave**.
 4. After all waves → auto-launch review.
+
+> **Do NOT paraphrase plan.md into the batch sub-agent's prompt.** plan.md is the source
+> of truth for task contracts (signatures, validation rules, error messages, file paths).
+> The implementer reads it directly. Your batch prompt only needs:
+>   - the batch ID and the task IDs in this batch (e.g. `Batch A → T001`)
+>   - a one-line pointer: "Read `.sdd/{change}/plan.md` Phase X → TXXX for the full contract"
+>   - the path to `plan.md`
+>   - any cross-batch context the implementer cannot infer (e.g. "Batch A finished; this batch depends on its output")
+>
+> Re-stating the contract risks drift between your prompt and plan.md, costs tokens on every
+> launch, and makes review harder (now there are two specs to reconcile). The Sequential Batch
+> Template in `{SHARED_DIR}/launch-templates.md` already follows this shape — fill it, do not
+> rewrite it.
 
 ## Post-Review Fix Cycle
 
@@ -420,7 +457,7 @@ Next Steps, Relevant Files.
 4. **Post-Phase skipping**: System-level "be concise" instructions do NOT override the
    Post-Phase Protocol.
 5. **Crit timeout ≠ approval**: If `crit plan` is killed by timeout or fails, the absence of
-   `.crit.json` means the review was NEVER completed — NOT that it was approved with no
+   `.crit/review.json` means the review was NEVER completed — NOT that it was approved with no
    comments. ALWAYS ask the user before proceeding to implement.
 
 ## References

--- a/workflows/sdd/_shared/envelope-contract.md
+++ b/workflows/sdd/_shared/envelope-contract.md
@@ -4,9 +4,25 @@ Every SDD skill (explore, plan, implement, review) MUST return the SDD Envelope 
 
 ## Rules
 
-1. The envelope is the FINAL output of the skill. No text, explanation, or follow-up after it.
-2. Skills NEVER invoke other SDD skills. Return the envelope; the orchestrator decides what runs next.
-3. Executive Summary must be **decision-grade** -- the orchestrator presents it to the user without reading full artifacts.
+1. **The envelope is the FINAL output of the skill.** No text, explanation, follow-up, or
+   "next steps" message may appear after the envelope. The orchestrator parses the envelope
+   verbatim — anything after the closing risk bullet (or after the last field of the envelope
+   block) is discarded as drift.
+2. **The envelope MUST match the template format below exactly.** Do not invent extra fields,
+   re-order the table rows, or wrap the envelope in ASCII boxes / decorative banners. The
+   orchestrator parses by field name; deviations break parsing for weaker models.
+3. Skills NEVER invoke other SDD skills. Return the envelope; the orchestrator decides what runs next.
+4. Executive Summary must be **decision-grade** -- the orchestrator presents it to the user without reading full artifacts.
+
+### Common drift patterns to avoid
+
+| ❌ Drift | ✅ Correct |
+|---|---|
+| ASCII art frame around the envelope (`┌────┐ ... └────┘`) | Plain markdown table per the template |
+| Adding a "## Summary" or "## Conclusion" section AFTER the envelope | Put summary content in `### Executive Summary` |
+| Restating the envelope as bullets after the table | Just the table |
+| "Listo para siguiente fase: ..." or similar follow-up prose | Put the next action in `### Next Recommended` |
+| Extra fields like `Effort` / `Confidence` / `Tags` not in the template | Stick to the template; extra fields break parsing |
 
 ## Status Values
 


### PR DESCRIPTION
## Summary

Audit findings from a real OpenCode SDD session driven by Opus 4.7 (\`session-ses_1ed8.md\`). Opus completed the workflow end-to-end, but the session surfaced friction points that would cripple weaker models — gpt-5.5 already hit the same patterns in earlier tests. All seven improvements are bundled here so a single sync picks them up together.

## Changes

### A. Crit feedback path bug fix

The catalog said \`~/.crit/plans/{change}/.crit.json\` but the daemon writes \`~/.crit/plans/{change}/.crit/review.json\`. Opus discovered the correct path from the daemon's own response and recovered. A weaker model would have followed the wrong path and never read the feedback.

**Files**: ORCHESTRATOR.md / ORCHESTRATOR.{claude,copilot,opencode}.md.

### B. Pre-action narration: explicit examples added

The old table covered \"Let me / I'll / Now I'll...\" but did not catch the phase-transition narration patterns observed in the session: \"Auto-launching plan\", \"Re-lanzo Crit para Round 2\", \"Cambio a una rama nueva...\". Added these as concrete ❌ rows in the OpenCode and Copilot variants.

### C. \`bash echo\` as marker — explicitly forbidden

Observed twice in the session: \`bash: echo \"Question for user\"\` followed by an actual question. The model treated the no-op echo as a required tool-call before \"speaking\". Added a dedicated forbidden table that calls out the question tool (\`question\` for OpenCode, \`vscode/askQuestions\` for Copilot) as a valid action without any preceding marker.

### D. Batch tasks must point to plan.md, NOT paraphrase

The orchestrator was re-stating ~1000 chars of task contract from \`plan.md\` inside each batch sub-agent prompt. Added a blockquote in the Implement section telling the orchestrator to fill the Sequential Batch Template with batch ID + path to plan.md only. Source-of-truth stays in plan.md; no drift, fewer tokens, less thinking time.

### E. Tool names corrected per agent

The catalog used \`AskUserQuestion\` everywhere — that's the Claude tool name. Per agent docs:
- **OpenCode**: tool is \`question\` (lowercase, per [opencode.ai/docs/tools](https://opencode.ai/docs/tools/#question))
- **Copilot**: tool is \`vscode/askQuestions\` (invoked as \`#tool:vscode/askQuestions\`, per VS Code Copilot docs)

\`ORCHESTRATOR.opencode.md\` now uses \`question\`. \`ORCHESTRATOR.copilot.md\` points at \`#tool:vscode/askQuestions\`. \`ORCHESTRATOR.claude.md\` and \`ORCHESTRATOR.md\` (generic) keep \`AskUserQuestion\` / generic phrasing — those are the correct names there.

### F. Envelope contract reinforcement

Added a \"common drift patterns\" table to \`_shared/envelope-contract.md\` covering: ASCII art frames around the envelope (observed in session-ses_1f19), restating the envelope as bullets after the table, \"Listo para siguiente fase:\" follow-up prose, and extra non-template fields (Effort, Confidence, etc.).

The \"envelope is the FINAL output\" rule is now phrased as parser-grade (\"anything after the closing risk bullet is discarded as drift\").

### G. Outcome statements removed from Allowed classes

The old \"Allowed — only these four classes\" included \"Outcome statements when a phase / wave / commit closes — one line\". This invited narration like \"Plan aprobado vía Crit. Actualizo state y lanzo implement.\" after EVERY transition. The sub-agent envelope already conveys what closed.

The Allowed list now has THREE classes: Questions, Envelope summaries, Errors/blockers. Explicit note explains that outcome statements are absorbed into class 1 (Questions) when the next user move is a decision.

## Compatibility

Pure markdown edits. No DevRune renderer changes. Safe to merge independently.

## Test plan

- [ ] Merge + \`devrune sync\`.
- [ ] Run an SDD session in OpenCode and confirm:
  - Crit reads from \`.crit/review.json\` (not \`.crit.json\`).
  - The orchestrator uses \`question\` (no \`AskUserQuestion\`).
  - No phase-transition narration like \"Auto-launching X\" / \"Re-lanzo Y\".
  - No \`bash echo\` markers before questions or other actions.
  - Batch sub-agent prompts are short — point to plan.md, no contract paraphrasing.
- [ ] Same in Copilot — confirm \`#tool:vscode/askQuestions\` references resolve.
- [ ] Sub-agent envelopes match the template exactly (no ASCII art, no extra fields).
- [ ] Claude install unchanged: \`AskUserQuestion\` still in place.

Source for the audit: \`session-ses_1ed8.md\` in the \`libraries/\` workspace.