### PR TITLE
fix(workflows/sdd): add strict state.yaml directive to Claude variant + cleanup AskUserQuestion mention

### DIFF
--- a/workflows/sdd/ORCHESTRATOR.claude.md
+++ b/workflows/sdd/ORCHESTRATOR.claude.md
@@ -104,7 +104,7 @@ The PRD is opt-in for thin contexts only — never force it, never offer it when
 **Trust the envelope.** A sub-agent that returns `status: ok` with a `Gates:` line listing project gate results (build / test / lint / format / type-check — whatever the project uses) has already run those gates and passed. The orchestrator MUST NOT re-run any verification command after an `ok` envelope — that's the implementer's contract, and re-running burns tokens, time, and Output Discipline. Only when an envelope returns `status: warning` or `status: failed` does manual validation belong here, and even then only on the specific signals the envelope flagged.
 
 1. **Parse** the SDD Envelope from sub-agent output (format: `_shared/envelope-contract.md`). For parallel implement waves: run steps 1–3 for EACH sub-agent envelope. Aggregate status: all `ok` → `ok`; any `failed` → `failed`; any `warning` (none failed) → `warning`.
-2. **Write state.yaml**: `.sdd/{change}/state.yaml` per schema in `_shared/persistence-contract.md`. For parallel waves: highest-severity status wins.
+2. **Write state.yaml STRICTLY** per the schema in `_shared/persistence-contract.md`. Use ONLY the field names listed in the schema (REQUIRED + OPTIONAL sections). Do NOT invent any other fields — the contract enumerates what is forbidden and why. If you think a new field is needed, the answer is no — propose a contract change first. For parallel waves: highest-severity status wins.
 3. **Engram** (if available): save `{phase}-summary`, `state`, and update `active-workflow` marker with NEXT directive.
 
    **NEXT Step Resolution**:

--- a/workflows/sdd/ORCHESTRATOR.opencode.md
+++ b/workflows/sdd/ORCHESTRATOR.opencode.md
@@ -55,9 +55,9 @@ both. The narration adds nothing the diff or the next tool call won't already co
 
 **Forbidden — bash echo as a "marker" before a question or another action**:
 
-The `question` tool and `AskUserQuestion`-equivalent prompts ARE valid actions on their own.
-You do NOT need a `bash echo` (or any other no-op tool call) before them. If your next move
-is to ask the user, ask. If your next move is to read a file, read it.
+The `question` tool IS a valid action on its own. You do NOT need a `bash echo` (or any
+other no-op tool call) before it. If your next move is to ask the user, ask. If your next
+move is to read a file, read it.
 
 | ❌ Don't do this | ✅ Do this |
 |---|---|


### PR DESCRIPTION
## Summary

Two small follow-ups uncovered by post-merge verification of PR #67 in a fresh install of both Claude and OpenCode:

### 1. Claude variant missed the strict directive

PR #67 added the \"Write state.yaml STRICTLY...do not invent fields\" directive to \`ORCHESTRATOR.{md,opencode.md,copilot.md}\` but skipped \`ORCHESTRATOR.claude.md\`. The Claude renderer prefers the \`.claude.md\` variant when present, so the generic \`ORCHESTRATOR.md\` change had no effect for Claude installs.

Verified post-sync: \`.claude/skills/sdd-orchestrator/SKILL.md\` line 141 had the OLD wording (\`Write state.yaml: per schema in...\`) and not the new strict directive.

This PR copies the same directive into the Claude variant Post-Phase Step 2.

### 2. OpenCode prompt leaked Claude tool name

\`ORCHESTRATOR.opencode.md\` L58 said:
\`\`\`
The \`question\` tool and \`AskUserQuestion\`-equivalent prompts ARE valid actions on their own.
\`\`\`

Mentioning \`AskUserQuestion\` in the OpenCode prompt is noise — only \`question\` is the actual OpenCode tool. Trimmed to just \`question\`.

## Files changed

- \`workflows/sdd/ORCHESTRATOR.claude.md\` — strict directive in Step 2 of Post-Phase Protocol.
- \`workflows/sdd/ORCHESTRATOR.opencode.md\` — drop the \`AskUserQuestion\`-equivalent mention from the bash-echo guard.

## Compatibility

Pure markdown edits in the catalog. No DevRune renderer changes. Safe to merge independently.

## Test plan

- [ ] Merge + \`devrune sync\` against a Claude install and verify \`.claude/skills/sdd-orchestrator/SKILL.md\` has the new strict directive at Post-Phase Step 2.
- [ ] Verify OpenCode \`opencode.json\` orchestrator prompt no longer references \`AskUserQuestion\`.
- [ ] Re-test an SDD session in Claude — confirm state.yaml only carries documented fields.