### PR TITLE
fix(tools): correct crit brew install command

### DIFF
--- a/tools/crit.yaml
+++ b/tools/crit.yaml
@@ -1,6 +1,6 @@
 name: crit
 description: "Code review tool for SDD workflows"
-command: "brew install tomasz-tomczyk/tap/crit"
+command: "brew install crit"
 binary: crit
 depends_on:
   workflow: sdd


### PR DESCRIPTION
## Bug Fix

### Issue
The tool definition for \`crit\` declared the install command as:

\`\`\`yaml
command: \"brew install tomasz-tomczyk/tap/crit\"
\`\`\`

That tap does not resolve. When DevRune consumes this catalog and a user runs **Upgrade Tools** from the menu, the command fails with \`exit status 1\`.

### Root Cause
The tap path is incorrect. The official Homebrew formula for crit is available on Homebrew core — no tap is needed.

### Fix
\`\`\`diff
-command: \"brew install tomasz-tomczyk/tap/crit\"
+command: \"brew install crit\"
\`\`\`

### Verification
\`\`\`console
\$ brew install crit
crit 0.11.0 is already installed but outdated (so it will be upgraded).
==> Pouring crit--0.12.0.arm64_tahoe.bottle.tar.gz
🍺  /opt/homebrew/Cellar/crit/0.12.0: 6 files, 13.6MB
\`\`\`

### Related
- DevRune PR davidarce/DevRune#73 (Upgrade Tools feature) hits this on every \`crit\` upgrade attempt.
- DevRune-side mitigation in the same PR: catalog now wins over manifest \`command\` override, so consumers' stale \`devrune.yaml\` files get the corrected command automatically after a sync.