### PR TITLE
fix(workflows/sdd): migrate sdd-session-compact.sh to canonical state.yaml schema

### DIFF
--- a/workflows/sdd/hooks/sdd-session-compact.sh
+++ b/workflows/sdd/hooks/sdd-session-compact.sh
@@ -1,29 +1,28 @@
 #!/bin/sh
 # SDD SessionStart(compact) Hook (Tier 1a — Claude only)
 # Fires when Claude resumes after compaction. Stdout becomes visible context.
+# Reads the canonical state.yaml schema (phase + next, per persistence-contract.md).
+# Skips terminal workflows (phase=done or next=done) — no recovery needed.
 # Searches root and one level of subdirectories for .sdd/*/state.yaml.
 find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read -r state_file; do
   change_name="$(basename "$(dirname "$state_file")")"
-  current_phase="$(grep '^current_phase:' "$state_file" | sed 's/current_phase: *//')"
-  next_step="$(grep '^next_step:' "$state_file" | sed 's/next_step: *//')"
-  [ -z "$current_phase" ] && current_phase="unknown"
-  [ -z "$next_step" ] && next_step="check state.yaml for details"
+  phase="$(grep '^phase:' "$state_file" | sed 's/phase: *//' | tr -d ' ')"
+  next="$(grep '^next:' "$state_file" | sed 's/next: *//' | tr -d ' ')"
+  [ -z "$phase" ] && phase="unknown"
+  [ -z "$next" ] && next="unknown"
+
+  case "$phase" in done) continue ;; esac
+  case "$next"  in done) continue ;; esac
 
   cat <<EOF
-CRITICAL: SDD workflow "${change_name}" was active during compaction. You MUST run compaction recovery NOW.
+## SDD recovery — workflow ${change_name}
 
-## Role Invariant — you orchestrate, you do not implement
+State file: ${state_file} (phase=${phase}, next=${next}).
 
-Outside .sdd/{change}/, your only outputs are: sub-agent launches (Task / Agent / @<sub-agent>), AskUserQuestion, mkdir for .sdd/, and Bash(crit ...) per the Crit Plan Review Protocol.
+Resume from \`next\` directly. Do NOT re-explore, re-plan or re-do
+completed phases. Read ${state_file} if you need more context.
 
-You do NOT: Edit/Write source files, run builds/tests/lints, run git commit/push, create branches/commits/PRs, invoke Skill("sdd-{phase}") directly.
-
-If your next planned action is on the "do not" list, you have lost the role — re-read ORCHESTRATOR.md and delegate.
-
-## Recovery
-
-State: ${state_file} (current_phase: ${current_phase}, NEXT: ${next_step}).
-Check engram for the active-workflow marker (mem_context).
-Load Skill(sdd-orchestrator) and resume from the NEXT directive.
+Do NOT produce any orientation or "I'll continue with..." sentence
+before resuming — the next tool call IS the resume. Just call it.
 EOF
 done


### PR DESCRIPTION
## Summary

Follow-up to #67. That PR rewrote the OpenCode compaction plugin (`workflows/sdd/plugins/sdd-compaction.ts`) to the canonical `state.yaml` schema but left the Claude Tier-1a `SessionStart(compact)` hook (`workflows/sdd/hooks/sdd-session-compact.sh`) on the old contract. As a result Claude installs got a broken recovery push on every compaction.

The stale hook:

- parsed `current_phase:` / `next_step:` — field names that no longer exist; the orchestrator writes `phase:` / `next:`, so the regexes never matched and every push said `current_phase: unknown / NEXT: check state.yaml`
- re-injected the **Role Invariant** block and the `Load Skill(sdd-orchestrator)` instruction (the jailbreak vector removed elsewhere) — wasteful and re-introduced patterns the catalog has since cleaned up
- carried the `CRITICAL: ... you MUST run compaction recovery NOW` preamble
- did **not** skip terminal workflows (`phase: done` / `next: done`)

## Changes

`workflows/sdd/hooks/sdd-session-compact.sh` — brought in lockstep with `plugins/sdd-compaction.ts`:

- parses `phase:` / `next:` (canonical schema, post #67)
- skips terminal workflows (`phase: done` or `next: done`)
- drops the Role Invariant / `Load Skill` / `CRITICAL...recovery NOW` prose — the orchestrator already has its full playbook
- adds the explicit "do NOT produce an orientation sentence" directive in the pushed context (mirrors what #67 added to the `.ts` plugin)
- recovery push shrunk from ~25 lines to ~7 per active workflow

Header stays `Tier 1a — Claude only`: `hooks/sdd-hooks-factory.json` wires only `sdd-pre-compact.sh`, not `sdd-session-compact.sh`.

## Compatibility

Pure catalog change (one shell script). No DevRune renderer changes. Safe to merge independently.

## Test plan

- [ ] Merge + `devrune sync` against a Claude install; verify `.claude/hooks/sdd-session-compact.sh` parses `phase:` / `next:`, has no Role Invariant / `Load Skill`, and includes the "no orientation sentence" directive.
- [ ] Hand-craft a canonical `state.yaml` (`phase: plan`, `next: implement`), trigger a compaction in Claude, confirm the recovery push reports `phase=plan, next=implement` (not `unknown`).
- [ ] Hand-craft a terminal `state.yaml` (`phase: done`), trigger a compaction, confirm no recovery push for that workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)