### PR TITLE
fix(workflows/sdd): scope compaction hooks to active workflow only

### DIFF
--- a/workflows/sdd/_shared/launch-templates.md
+++ b/workflows/sdd/_shared/launch-templates.md
@@ -139,7 +139,28 @@ The orchestrator populates `{formatted markdown list}` using the CRIT_FEEDBACK f
 
 ## Initial Workflow Marker
 
-Before the FIRST sub-agent launch in a new SDD workflow, the orchestrator saves (if engram available):
+Before the FIRST sub-agent launch in a new SDD workflow, the orchestrator MUST do BOTH:
+
+### 1. On-disk marker (mandatory, no dependencies)
+
+Write the active workflow name to `.sdd/.active` (single-line, just the change-name):
+
+```
+echo "{change}" > .sdd/.active
+```
+
+This is the source of truth read by the SDD compaction hooks (`sdd-pre-compact.sh`, `sdd-session-compact.sh`, `sdd-compaction.ts`). Without this file, hooks fall back to scanning every `.sdd/*` directory and emit noise for dormant or archived workflows.
+
+**Lifecycle**:
+- **Written** when the workflow starts (before first sub-agent launch).
+- **Left in place** through every phase transition — the active workflow name does not change mid-workflow.
+- **Deleted** when the workflow ends (completed, aborted, or user explicitly closes):
+
+```
+rm -f .sdd/.active     # on workflow close (any terminal state)
+```
+
+### 2. Engram marker (best-effort, if engram available)
 
 ```
 mem_save(
@@ -150,4 +171,10 @@ mem_save(
 )
 ```
 
+The engram marker carries the richer NEXT directive used by recovery. The `.sdd/.active` file carries only the change-name and is read by the language-agnostic compaction hooks.
+
 This enables compaction recovery (see `_shared/recovery.md`).
+
+> NOTE: The same "Initial Workflow Marker" section appears in the per-assistant variants
+> (`launch-templates.claude.md`, `.copilot.md`, `.opencode.md`). Until those variants are
+> regenerated from this base, port the on-disk marker steps into each one manually.

--- a/workflows/sdd/_shared/persistence-contract.md
+++ b/workflows/sdd/_shared/persistence-contract.md
@@ -114,7 +114,20 @@ mem_save(
 
 This provides an additional recovery path if `.sdd/` files are lost, but is NEVER required.
 
-### Role Marker for Compaction Recovery
+### On-Disk Active Marker (mandatory)
+
+The orchestrator MUST maintain `.sdd/.active` as a single-line file containing the active change-name:
+
+```
+echo "{change}" > .sdd/.active   # on workflow start
+rm  -f .sdd/.active              # on workflow close (abort or complete)
+```
+
+This is the canonical signal read by language-agnostic compaction hooks (`sdd-pre-compact.sh`, `sdd-session-compact.sh`, `sdd-compaction.ts`). Without it, hooks fall back to scanning every `.sdd/*/state.yaml` and emit noise for dormant or archived workflows.
+
+The orchestrator's existing sole-writer contract over `state.yaml` extends to `.sdd/.active`: only the orchestrator writes/deletes this file.
+
+### Role Marker for Compaction Recovery (engram, best-effort)
 
 If engram is available, the orchestrator ALSO saves an active-workflow role marker alongside the state:
 

--- a/workflows/sdd/_shared/recovery.md
+++ b/workflows/sdd/_shared/recovery.md
@@ -47,7 +47,17 @@ When an envelope returns `status: failed` or `status: blocked`:
 
 ## Abort / Complete Cleanup
 
-When a workflow ends (user aborts or completes), clear the active-workflow marker (if engram available):
+When a workflow ends (user aborts or completes), the orchestrator MUST do BOTH:
+
+### 1. Remove the on-disk marker (mandatory)
+
+```
+rm -f .sdd/.active
+```
+
+This silences the SDD compaction hooks for this workflow (the active path short-circuits when the file is absent and falls back to canonical-schema scan, which already skips `phase=done|next=done`).
+
+### 2. Update the engram marker (best-effort, if engram available)
 
 ```
 mem_save(

--- a/workflows/sdd/hooks/sdd-pre-compact.sh
+++ b/workflows/sdd/hooks/sdd-pre-compact.sh
@@ -1,8 +1,29 @@
 #!/bin/sh
-# SDD Pre-Compaction Hook
-# Ensures .sdd/ state is persisted before context compaction.
-# Searches root and one level of subdirectories for .sdd/*/state.yaml.
+# SDD Pre-Compaction Hook (v2 — active-marker aware)
+# Strategy:
+#  1. If .sdd/.active exists -> touch only that workflow's state.yaml
+#     (single source of truth maintained by the orchestrator).
+#  2. Fallback: scan .sdd/*/state.yaml but require canonical schema
+#     (phase: + next: keys). Old-schema files (current_phase:/phases:)
+#     are skipped silently as dormant.
+#  3. Always skip workflows where phase=done or next=done.
+
+if [ -f .sdd/.active ]; then
+  active="$(tr -d '[:space:]' < .sdd/.active)"
+  if [ -n "$active" ] && [ -f ".sdd/$active/state.yaml" ]; then
+    touch ".sdd/$active/state.yaml"
+    echo "[sdd-hook] Pre-compaction: verified state for $active (active marker)"
+  fi
+  exit 0
+fi
+
 find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read -r state_file; do
+  grep -q '^phase:' "$state_file" || continue
+  grep -q '^next:'  "$state_file" || continue
+  phase="$(grep '^phase:' "$state_file" | sed 's/phase: *//' | tr -d ' ')"
+  next="$(grep '^next:'   "$state_file" | sed 's/next: *//'  | tr -d ' ')"
+  case "$phase" in done) continue ;; esac
+  case "$next"  in done) continue ;; esac
   change_name="$(basename "$(dirname "$state_file")")"
   touch "$state_file"
   echo "[sdd-hook] Pre-compaction: verified state for $change_name"

--- a/workflows/sdd/hooks/sdd-session-compact.sh
+++ b/workflows/sdd/hooks/sdd-session-compact.sh
@@ -1,19 +1,17 @@
 #!/bin/sh
-# SDD SessionStart(compact) Hook (Tier 1a — Claude only)
-# Fires when Claude resumes after compaction. Stdout becomes visible context.
-# Reads the canonical state.yaml schema (phase + next, per persistence-contract.md).
-# Skips terminal workflows (phase=done or next=done) — no recovery needed.
-# Searches root and one level of subdirectories for .sdd/*/state.yaml.
-find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read -r state_file; do
-  change_name="$(basename "$(dirname "$state_file")")"
-  phase="$(grep '^phase:' "$state_file" | sed 's/phase: *//' | tr -d ' ')"
-  next="$(grep '^next:' "$state_file" | sed 's/next: *//' | tr -d ' ')"
-  [ -z "$phase" ] && phase="unknown"
-  [ -z "$next" ] && next="unknown"
+# SDD SessionStart(compact) Hook (Tier 1a — Claude only, v2 active-marker aware).
+# Strategy:
+#  1. If .sdd/.active exists -> emit recovery for that one workflow only.
+#  2. Fallback: scan .sdd/*/state.yaml but require canonical schema
+#     (phase: + next: keys). Old-schema files (current_phase:/phases:)
+#     are skipped silently as dormant.
+#  3. Always skip workflows where phase=done or next=done.
 
-  case "$phase" in done) continue ;; esac
-  case "$next"  in done) continue ;; esac
-
+emit_recovery() {
+  change_name="$1"
+  state_file="$2"
+  phase="$3"
+  next="$4"
   cat <<EOF
 ## SDD recovery — workflow ${change_name}
 
@@ -25,4 +23,30 @@ completed phases. Read ${state_file} if you need more context.
 Do NOT produce any orientation or "I'll continue with..." sentence
 before resuming — the next tool call IS the resume. Just call it.
 EOF
+}
+
+if [ -f .sdd/.active ]; then
+  active="$(tr -d '[:space:]' < .sdd/.active)"
+  state_file=".sdd/$active/state.yaml"
+  if [ -n "$active" ] && [ -f "$state_file" ]; then
+    phase="$(grep '^phase:' "$state_file" | sed 's/phase: *//' | tr -d ' ')"
+    next="$(grep '^next:'   "$state_file" | sed 's/next: *//'  | tr -d ' ')"
+    [ -z "$phase" ] && phase="unknown"
+    [ -z "$next" ]  && next="unknown"
+    case "$phase" in done) exit 0 ;; esac
+    case "$next"  in done) exit 0 ;; esac
+    emit_recovery "$active" "$state_file" "$phase" "$next"
+  fi
+  exit 0
+fi
+
+find . -maxdepth 3 -path '*/.sdd/*/state.yaml' -type f 2>/dev/null | while read -r state_file; do
+  grep -q '^phase:' "$state_file" || continue
+  grep -q '^next:'  "$state_file" || continue
+  change_name="$(basename "$(dirname "$state_file")")"
+  phase="$(grep '^phase:' "$state_file" | sed 's/phase: *//' | tr -d ' ')"
+  next="$(grep '^next:'   "$state_file" | sed 's/next: *//'  | tr -d ' ')"
+  case "$phase" in done) continue ;; esac
+  case "$next"  in done) continue ;; esac
+  emit_recovery "$change_name" "$state_file" "$phase" "$next"
 done

--- a/workflows/sdd/plugins/sdd-compaction.ts
+++ b/workflows/sdd/plugins/sdd-compaction.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import type { Plugin } from "@opencode-ai/plugin";
 
 const SDD_DIR = ".sdd";
+const ACTIVE_MARKER = join(SDD_DIR, ".active");
 
 // Terminal phase / next values per the canonical schema in
 // _shared/persistence-contract.md. When a workflow has reached one of
@@ -10,8 +11,37 @@ const SDD_DIR = ".sdd";
 const TERMINAL_PHASES = new Set(["done"]);
 const TERMINAL_NEXTS = new Set(["done"]);
 
-// SddCompaction pushes a minimal recovery context block per active SDD
-// workflow when OpenCode is about to compact the session.
+type Output = { context: { push: (s: string) => void } };
+
+// readStateMeta returns canonical phase/next values from a state.yaml
+// only if BOTH keys are present. Old-schema files (current_phase: /
+// phases:) return null and are treated as dormant by the caller.
+function readStateMeta(stateFile: string): { phase: string; next: string } | null {
+  const content = readFileSync(stateFile, "utf-8");
+  // Canonical schema (per persistence-contract.md):
+  //   phase:         explore | plan | implement | review | done
+  //   next:          explore | plan | implement | review | commit | pr | done
+  //   phase_status:  ok | warning | failed | blocked
+  const phaseMatch = content.match(/^phase:\s*(\S+)/m);
+  const nextMatch = content.match(/^next:\s*(\S+)/m);
+  if (!phaseMatch || !nextMatch) return null;
+  return { phase: phaseMatch[1], next: nextMatch[1] };
+}
+
+function emit(out: Output, name: string, stateFile: string, phase: string, next: string) {
+  out.context.push(
+`## SDD recovery — workflow \`${name}\`
+
+State file: \`${stateFile}\` (phase=${phase}, next=${next}).
+
+Resume from \`next\` directly. Do NOT re-explore, re-plan, or re-do any
+completed phase. Read \`${stateFile}\` only if you need more context
+than phase + next.`
+  );
+}
+
+// SddCompaction pushes a minimal recovery context block for the active
+// SDD workflow when OpenCode is about to compact the session.
 //
 // The push is intentionally lean: change-name, path to state.yaml, and
 // the canonical phase/next values parsed from that file. The full
@@ -22,45 +52,42 @@ const TERMINAL_NEXTS = new Set(["done"]);
 // compaction wastes context and re-introduces patterns the catalog
 // has since removed (PR-A: drop REGISTRY for primary agents; audit
 // PR #66: tool-name corrections; P3: allow workflow-init branch).
+//
+// Strategy (v2 — active-marker aware):
+//  1. If .sdd/.active exists -> emit recovery only for that workflow.
+//  2. Fallback: scan .sdd/*/state.yaml but require canonical schema.
+//     Old-schema files (current_phase:/phases:) are skipped silently.
+//  3. Always skip workflows where phase=done or next=done.
 export const SddCompaction: Plugin = async (_ctx) => {
   return {
-    "experimental.session.compacting": async (
-      _input: unknown,
-      output: { context: { push: (s: string) => void } }
-    ) => {
+    "experimental.session.compacting": async (_input: unknown, output: Output) => {
       if (!existsSync(SDD_DIR)) return;
 
+      if (existsSync(ACTIVE_MARKER)) {
+        const active = readFileSync(ACTIVE_MARKER, "utf-8").trim();
+        if (!active) return;
+        const stateFile = join(SDD_DIR, active, "state.yaml");
+        if (!existsSync(stateFile)) return;
+        const meta = readStateMeta(stateFile);
+        if (!meta) return;
+        if (TERMINAL_PHASES.has(meta.phase) || TERMINAL_NEXTS.has(meta.next)) return;
+        emit(output, active, stateFile, meta.phase, meta.next);
+        return;
+      }
+
       const changes = readdirSync(SDD_DIR, { withFileTypes: true })
-        .filter((d) => d.isDirectory())
+        .filter((d) => d.isDirectory() && d.name !== "archives")
         .filter((d) => existsSync(join(SDD_DIR, d.name, "state.yaml")));
 
       for (const c of changes) {
         const stateFile = join(SDD_DIR, c.name, "state.yaml");
-        const content = readFileSync(stateFile, "utf-8");
-
-        // Canonical schema (per persistence-contract.md):
-        //   phase:         explore | plan | implement | review | done
-        //   next:          explore | plan | implement | review | commit | pr | done
-        //   phase_status:  ok | warning | failed | blocked
-        const phase =
-          content.match(/^phase:\s*(\S+)/m)?.[1] ?? "unknown";
-        const next =
-          content.match(/^next:\s*(\S+)/m)?.[1] ?? "unknown";
-
+        const meta = readStateMeta(stateFile);
+        if (!meta) continue;
         // Skip recovery push for terminal workflows — re-injecting a
         // recovery directive after the workflow is done only invites
         // the orchestrator to re-do completed phases.
-        if (TERMINAL_PHASES.has(phase) || TERMINAL_NEXTS.has(next)) continue;
-
-        output.context.push(
-`## SDD recovery — workflow \`${c.name}\`
-
-State file: \`${stateFile}\` (phase=${phase}, next=${next}).
-
-Resume from \`next\` directly. Do NOT re-explore, re-plan, or re-do any
-completed phase. Read \`${stateFile}\` only if you need more context
-than phase + next.`
-        );
+        if (TERMINAL_PHASES.has(meta.phase) || TERMINAL_NEXTS.has(meta.next)) continue;
+        emit(output, c.name, stateFile, meta.phase, meta.next);
       }
     },
   };


### PR DESCRIPTION
Closes #75.

## Summary

- Both shell hooks (`sdd-pre-compact.sh`, `sdd-session-compact.sh`) and the OpenCode plugin (`sdd-compaction.ts`) now short-circuit on `.sdd/.active` — they process only the workflow the orchestrator declared active and exit.
- When no active marker is present, hooks fall back to scanning but require the canonical `state.yaml` schema (`phase:` + `next:` keys). Old-schema files (`current_phase:` / `phases:` map) are skipped silently as dormant.
- Orchestrator docs updated to make `.sdd/.active` part of the workflow lifecycle contract (mandatory write at start, mandatory delete at close).

## Why

A user with ~15 historical SDD workflows in `.sdd/` ran `/compact` and got 15 separate `## SDD recovery — workflow ...` directives pushed back into the agent. The agent now believes it has 15 active SDDs to resume — pure noise. See #75 for the full diagnosis.

Without this fix, the noise scales linearly with the number of SDDs ever started in the repo. With it, the noise floor is zero (no active marker) or one (the one the orchestrator named).

## Test plan

- [ ] In a fresh repo with `.sdd/.active` set to a real workflow name, both hooks emit recovery for that one workflow only.
- [ ] In a repo with `.sdd/.active` absent and only old-schema state files, both hooks emit nothing.
- [ ] In a repo with `.sdd/.active` absent and one canonical-schema state file in `phase=plan`, both hooks emit recovery for that one workflow.
- [ ] `phase=done` or `next=done` is still respected in both code paths.

## Reference

A version of this fix is already merged on `inditex/lib-purchaseai@migration/aicontext-first` (commit `fix(sdd): compaction hooks scope to active workflow only`), where it was first validated end-to-end against a real install with the 15-workflow noise problem.

## Follow-up

The per-assistant `launch-templates.{claude,copilot,opencode}.md` variants also carry an "Initial Workflow Marker" section. They are NOT updated in this PR; whoever next regenerates them should pick up the on-disk marker steps from `launch-templates.md` (base).